### PR TITLE
HermeticFetchContent v1.0.4 : No more force checkout of FetchContent projects when unclean state detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can run the HermeticFetchContent test suite this way:
 
   * `cmake -S . -B build/ -DCMAKE_TOOLCHAIN_FILE=toolchain/toolchain.cmake -GNinja` **[*]** 
   * `cmake --build build/`
-  * `ctest --test check_options_and_defines_forwarding`
+  * `ctest -R check_options_and_defines_forwarding`
 
 
 **[*]** Additionally the following variable can be defined to ease development:

--- a/cmake/modules/hfc_git_helpers.cmake
+++ b/cmake/modules/hfc_git_helpers.cmake
@@ -120,9 +120,9 @@ function(repo_has_revision)
     git_exec(COMMAND "${git_executable} cat-file -e ${FN_ARG_GIT_REVISION}" WORKING_DIRECTORY "${FN_ARG_REPOSITORY_DIR}" OUT_RETURN_CODE return_code)
 
     if(return_code EQUAL 0)
-        set(${FN_ARG_OUT_RESULT} true PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} TRUE PARENT_SCOPE)
     else()
-        set(${FN_ARG_OUT_RESULT} false PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} FALSE PARENT_SCOPE)
     endif()
 
 endfunction()
@@ -162,9 +162,9 @@ function(repo_has_revision)
     git_exec(COMMAND "${git_executable} cat-file -e ${FN_ARG_GIT_REVISION}" WORKING_DIRECTORY "${FN_ARG_REPOSITORY_DIR}" OUT_RETURN_CODE return_code)
 
     if(return_code EQUAL 0)
-        set(${FN_ARG_OUT_RESULT} true PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} TRUE PARENT_SCOPE)
     else()
-        set(${FN_ARG_OUT_RESULT} false PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} FALSE PARENT_SCOPE)
     endif()
 
 endfunction()
@@ -213,9 +213,9 @@ function(repo_is_clean)
     )
 
     if(cmd_output STREQUAL "")
-        set(${FN_ARG_OUT_RESULT} true PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} TRUE PARENT_SCOPE)
     else()
-        set(${FN_ARG_OUT_RESULT} false PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} FALSE PARENT_SCOPE)
     endif()
 
 endfunction()
@@ -307,7 +307,7 @@ function(checkout_revision_force_clean)
         hfc_log(STATUS "Repository ${FN_ARG_REPOSITORY_DIR} already at ${FN_ARG_GIT_REVISION} and clean - skipping")
         
         if(FN_ARG_OUT_SUCCESS)
-            set(${FN_ARG_OUT_SUCCESS} true PARENT_SCOPE)
+            set(${FN_ARG_OUT_SUCCESS} TRUE PARENT_SCOPE)
         endif()
         return()
     endif()
@@ -320,7 +320,7 @@ function(checkout_revision_force_clean)
         git_exec(COMMAND "${git_executable} submodule foreach --recursive ${git_executable} clean -xfdf" WORKING_DIRECTORY "${FN_ARG_REPOSITORY_DIR}" OUT_RETURN_CODE ret_stage0_clean_submodules)
 
         if(FN_ARG_OUT_SUCCESS AND (ret_stage0_clean_repo GREATER 0 OR ret_stage0_clean_submodules GREATER 0))
-            set(${FN_ARG_OUT_SUCCESS} false PARENT_SCOPE)
+            set(${FN_ARG_OUT_SUCCESS} FALSE PARENT_SCOPE)
             return()
         endif()        
     endif()
@@ -346,7 +346,7 @@ function(checkout_revision_force_clean)
     git_exec(COMMAND "${git_executable} checkout -f ${FN_ARG_GIT_REVISION}" WORKING_DIRECTORY "${FN_ARG_REPOSITORY_DIR}" OUT_RETURN_CODE ret_stage1_checkout)
     
     if(FN_ARG_OUT_SUCCESS AND ret_stage1_checkout GREATER 0) 
-        set(${FN_ARG_OUT_SUCCESS} false PARENT_SCOPE)
+        set(${FN_ARG_OUT_SUCCESS} FALSE PARENT_SCOPE)
         return()
     endif()
 
@@ -357,7 +357,7 @@ function(checkout_revision_force_clean)
     git_exec(COMMAND "${git_executable} submodule update --init --recursive" WORKING_DIRECTORY "${FN_ARG_REPOSITORY_DIR}" COMMAND_ERROR_IS_FATAL ANY)
 
     # \ö/
-    set(${FN_ARG_OUT_SUCCESS} true PARENT_SCOPE)
+    set(${FN_ARG_OUT_SUCCESS} TRUE PARENT_SCOPE)
 endfunction()
 
 
@@ -393,9 +393,9 @@ function(is_git_repository)
     endif()
 
     if(return_code EQUAL 0)
-        set(${FN_ARG_OUT_RESULT} true PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} TRUE PARENT_SCOPE)
     else()
-        set(${FN_ARG_OUT_RESULT} false PARENT_SCOPE)
+        set(${FN_ARG_OUT_RESULT} FALSE PARENT_SCOPE)
     endif()
 
 endfunction()

--- a/cmake/modules/hfc_goldilock_helpers.cmake
+++ b/cmake/modules/hfc_goldilock_helpers.cmake
@@ -48,9 +48,9 @@ function(hfc_goldilock_acquire dir success_var)
   )
 
   if(ret_code EQUAL 0)
-    set(${success_var} true PARENT_SCOPE)
+    set(${success_var} TRUE PARENT_SCOPE)
   else()
-    set(${success_var} false PARENT_SCOPE)
+    set(${success_var} FALSE PARENT_SCOPE)
     hfc_log(WARNING "Failed to acquire lock: ${lockfile_path}\n${command_stdoutput}")
   endif()
 
@@ -78,9 +78,9 @@ function(hfc_goldilock_release dir success_var)
   )
 
   if(ret_code EQUAL 0)
-    set(${success_var} true PARENT_SCOPE)
+    set(${success_var} TRUE PARENT_SCOPE)
   else()
-    set(${success_var} false PARENT_SCOPE)
+    set(${success_var} FALSE PARENT_SCOPE)
     hfc_log(WARNING "Failed to release lock: ${lockfile_path}\n${command_stdoutput}")
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,7 @@ set_property(TEST ensure_goldilock PROPERTY RUN_SERIAL ON) # run first and not i
 # all other tests
 # -> those all use the HFC_TEST_SHARED_TOOLS_DIR to avoid re-building goldilock a thousand times over
 set(test_source_files
+    "${CMAKE_CURRENT_LIST_DIR}/check_PATCH_COMMAND.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_compiler_forwarding.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_options_and_defines_forwarding.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_subdir.cpp"

--- a/test/check_PATCH_COMMAND.cpp
+++ b/test/check_PATCH_COMMAND.cpp
@@ -1,0 +1,73 @@
+#define BOOST_TEST_MODULE check_PATCH_COMMAND
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+  using namespace std::string_literals;
+
+  inline void remove_build_folder(bool is_cmake_re, fs::path template_path, std::string lib_name){
+    if(is_cmake_re){
+      for (const auto& entry : fs::directory_iterator{template_path / "build" / "_deps" / (lib_name+"-build") }){
+        fs::remove_all(entry.path());
+      }
+
+      for (const auto& entry : fs::directory_iterator{template_path / "build"}){
+        fs::remove_all(entry.path());
+      }
+    }
+    fs::remove_all(template_path / "build");
+  }
+
+   BOOST_DATA_TEST_CASE(check_PATCH_COMMAND_cmake, boost::unit_test::data::make(hfc::test::test_variants()), data){
+
+    fs::path test_project_path = prepare_project_to_be_tested("check_PATCH_COMMAND", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+
+    write_simple_main(test_project_path, {"MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h"});
+    
+    BOOST_REQUIRE(!fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h" ));
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "MyExample" ));
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "mathlib-install" / "include" / "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h"));
+
+    run_command(get_cmake_configure_command(test_project_path, data), test_project_path);
+
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path);
+
+    if ( !data.is_cmake_re ) {
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h" ));
+    }
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "MyExample" ));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "mathlib-install" / "include" / "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h"));
+    
+    remove_build_folder(data.is_cmake_re, test_project_path, "mathlib");
+
+
+    run_command(get_cmake_configure_command(test_project_path, data), test_project_path);
+
+    // Check that it is still patched after reconfigure
+    if ( !data.is_cmake_re ) { // in cmake-re it is in mirror
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h" ));
+    }
+
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "MyExample" ));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "mathlib-install" / "include" / "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h"));
+
+    remove_build_folder(data.is_cmake_re, test_project_path, "mathlib");
+  }
+
+}

--- a/test/test_project.hpp
+++ b/test/test_project.hpp
@@ -60,7 +60,7 @@ namespace hfc::test {
 
     {
       fs::path template_path = source_tree / "test" / "test_project_templates" / name_of_the_template;    
-      fs::copy(template_path, project_path);
+      fs::copy(template_path, project_path, fs::copy_options::recursive);
     }
 
     fs::path project_toolchain_dir = get_project_toolchain_dir(project_path);

--- a/test/test_project_templates/check_PATCH_COMMAND/CMakeLists.txt
+++ b/test/test_project_templates/check_PATCH_COMMAND/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  "mathlib"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92"
+  PATCH_COMMAND ${CMAKE_COMMAND} -E rename "MathFunctionscbrt.h" "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h"
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_LIST_DIR}/thirdparty/patch/CMakeLists.txt"  "CMakeLists.txt" 
+        COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_LIST_DIR}/thirdparty/patch/CMakeLists.txt"  "CMakeLists.txt"
+)
+
+FetchContent_MakeHermetic(
+  "mathlib"
+  HERMETIC_BUILD_SYSTEM cmake
+)
+
+HermeticFetchContent_MakeAvailableAtBuildTime("mathlib")
+
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::MathFunctions MathFunctionscbrt::MathFunctionscbrt)
+

--- a/test/test_project_templates/check_PATCH_COMMAND/thirdparty/patch/CMakeLists.txt
+++ b/test/test_project_templates/check_PATCH_COMMAND/thirdparty/patch/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.15)
+project(MathFunctions)
+
+# make cache variables for install destinations
+include(GNUInstallDirs)
+
+# specify the C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+add_library(MathFunctionscbrt STATIC MathFunctionscbrt.cxx)
+
+target_include_directories(MathFunctionscbrt
+                           PUBLIC
+                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
+
+install(TARGETS MathFunctionscbrt
+        EXPORT MathFunctionscbrtTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT MathFunctionscbrtTargets
+        FILE MathFunctionscbrtTargets.cmake
+        NAMESPACE MathFunctionscbrt::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MathFunctionscbrt
+)
+add_library(MathFunctions STATIC MathFunctions.cxx)
+
+target_include_directories(MathFunctions
+                           PUBLIC
+                           "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+                           "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
+
+
+install(TARGETS MathFunctions
+        EXPORT MathFunctionsTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES MathFunctions.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT MathFunctionsTargets
+        FILE MathFunctionsTargets.cmake
+        NAMESPACE MathFunctions::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MathFunctions
+)

--- a/test/test_project_templates/check_PATCH_COMMAND/thirdparty/patch/MathFunctionscbrt.cxx
+++ b/test/test_project_templates/check_PATCH_COMMAND/thirdparty/patch/MathFunctionscbrt.cxx
@@ -1,0 +1,10 @@
+#include "MathFunctionscbrt-MOVED-BY-PATCH_COMMAND.h"
+
+#include <cmath>
+
+namespace MathFunctions {
+double cbrt(double x)
+{
+  return std::cbrt(x);
+}
+}


### PR DESCRIPTION
This replaces the force checkout with a WARNING message informing of local modifications in the source cache but ultimately permitting it for debugging purposes.

This on one hand fixes a bug with patches being reset on second configure after a first failed run, but also on another hand allow developers to modify the source cache to attempt to pass and fix configuration without the need to push changes online and update the hash in the FetchContent_Declare.

It also fixes the true and false values in the repositories is_clean detection.

Change-Id: I0706eed78eeaaa972545ef1038d0bc011a31ad0e