### PR TITLE
HermeticFetchContent v1.0.12 : Fix cmake-re cached project retrieval with HERMETIC_PREPATCHED_RESOLVER

### DIFF
--- a/cmake/modules/hfc_make_available_single.cmake
+++ b/cmake/modules/hfc_make_available_single.cmake
@@ -238,9 +238,39 @@ function(hfc_make_available_single content_name build_at_configure_time)
   hfc_create_restore_prefixes(${content_name} ${__PARAMS_BINARY_DIR} ${cmake_contentInstallPath})
 
   # register the content/project specific populate() function
-  hfc_populate_project_declare(${content_name})  
+  set(origin_with_resolved_patch "")
 
+  hfc_populate_project_declare(${content_name})  
   hfc_determine_cache_id(${content_name})
+
+  if(__PARAMS_HERMETIC_PREPATCHED_RESOLVER)
+
+    hfc_evaluate_prepatched_resolver(
+      OUT_VAR_PREFIX prepatched_
+      HERMETIC_PREPATCHED_RESOLVER "${__PARAMS_HERMETIC_PREPATCHED_RESOLVER}"
+
+      URL "${__PARAMS_URL}"
+      URL_HASH "${__PARAMS_URL_HASH}"
+      GIT_REPOSITORY "${__PARAMS_GIT_REPOSITORY}"
+      GIT_TAG "${__PARAMS_GIT_TAG}"
+      GIT_SUBMODULES "${__PARAMS_GIT_SUBMODULES}"
+      SOURCE_DIR "${__PARAMS_SOURCE_DIR}"
+    )
+
+    if(prepatched_RESOLVED_PATCH)
+      if(prepatched_URL)
+        set(origin_with_resolved_patch "${prepatched_URL}")
+      elseif(prepatched_GIT_REPOSITORY)
+        set(origin_with_resolved_patch "${prepatched_GIT_REPOSITORY}")
+      endif()
+    endif()
+
+  endif()
+
+  if(origin_with_resolved_patch)
+    # Use the prepatched origin as cache-key
+    set (${content_name}_origin "${origin_with_resolved_patch}")
+  endif()
 
   # select the project scheme based on build system name info
   if(NOT DEFINED __PARAMS_HERMETIC_BUILD_SYSTEM)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,6 +104,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_prepatch_resolver.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_prepatch_resolver.cpp
+++ b/test/check_prepatch_resolver.cpp
@@ -1,0 +1,41 @@
+#define BOOST_TEST_MODULE check_prepatch_resolver
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+  using namespace std::string_literals;
+
+  BOOST_DATA_TEST_CASE(check_that_resolver_is_used_and_origin_changed, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path template_path = prepare_project_to_be_tested("check_prepatch_resolver", data.is_cmake_re);
+    write_simple_main(template_path,{"MathFunctions.h", "MathFunctionscbrt.h", "MathFunctionsmultiplybytwo.h"});
+
+    std::string cmake_configure_command = get_cmake_configure_command(template_path, data);    
+    run_command(cmake_configure_command, template_path);
+    run_command(get_cmake_build_command(template_path, data), template_path);
+
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "MyExample" ));
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "_deps" / "mathlib-install" / "lib" / "libMathFunctions.a"));
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "_deps" / "mathlib-install" / "lib" / "libMathFunctionscbrt.a"));
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "_deps" / "mathlib-install" / "lib" / "libMathFunctionsmultiplybytwo.a"));
+
+
+    if(data.is_cmake_re){
+      fs::path mathlib_install_path = template_path / "build" / "_deps" / "mathlib-install";
+      fs::path mathlib_install_path_no_symlink = fs::read_symlink(mathlib_install_path);
+      BOOST_REQUIRE(boost::contains(mathlib_install_path_no_symlink.generic_string() ,"unit-test-cmake-template-2libs-simulation-prepatch"));
+    }
+  }
+}

--- a/test/test_project_templates/check_prepatch_resolver/CMakeLists.txt
+++ b/test/test_project_templates/check_prepatch_resolver/CMakeLists.txt
@@ -1,0 +1,42 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
+set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  "mathlib"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92"
+  PATCH_COMMAND "${CMAKE_COMMAND} -E environment"
+)
+
+FetchContent_MakeHermetic(
+  "mathlib"
+  HERMETIC_BUILD_SYSTEM cmake
+  HERMETIC_PREPATCHED_RESOLVER [=[
+  if(${GIT_TAG} STREQUAL "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92")
+     set(GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs-simulation-prepatch")
+     set(GIT_TAG "7b661a3c99164648f2209b811cea4d12b9858e67")
+     set(RESOLVED_PATCH TRUE)
+  endif()
+ ]=]
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime("mathlib")
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::MathFunctions MathFunctionscbrt::MathFunctionscbrt MathFunctionsmultiplybytwo::MathFunctionsmultiplybytwo)
+


### PR DESCRIPTION
HermeticFetchContent v1.0.12 : Fix cmake-re cached project retrieval with HERMETIC_PREPATCHED_RESOLVER

Retrieve the right cache entry when HermeticFetchContent is used with an
HERMETIC_PREPATCHED_RESOLVER, it otherwise would wrongfully use the origin
of the source project as cache-key, which would be correct when the project
get patched during the build but not when a prepatched resolver succeeds.

HERMETIC_PREPATCHED_RESOLVER are meant to help clean builds for non-project
maintainers.

Co-authored-by: Damien Buhl <damien@tipi.build>
Co-authored-by: Luc Lambour <luc@tipi.build>

Change-Id: I0706eed78ddbbb972545ef1038d0bc011a31ad0e

Close https://github.com/nxxm/nxxm-src/issues/1467