### PR TITLE
Test for FETCHCONTENT_BASE_DIR

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,6 +102,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/goldilock_provisioning_test.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_source_build_hfc_prefix.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_change_FETCHCONTENT_BASE_DIR.cpp
+++ b/test/check_change_FETCHCONTENT_BASE_DIR.cpp
@@ -1,0 +1,92 @@
+#define BOOST_TEST_MODULE check_change_FETCHCONTENT_BASE_DIR
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+
+namespace hfc::test {
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+  using namespace std::string_literals;
+
+  BOOST_DATA_TEST_CASE(FETCHCONTENT_BASE_DIR_works, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_change_base_dir", data.is_cmake_re);
+    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h","lib.h"});
+
+    fs::path overridden_FETCHCONTENT_BASE_DIR = test_project_path / "change_base";
+    fs::create_directories(overridden_FETCHCONTENT_BASE_DIR);
+
+    run_command(
+      get_cmake_configure_command(test_project_path, data)
+      + " -DFETCHCONTENT_BASE_DIR="s + overridden_FETCHCONTENT_BASE_DIR.generic_string(), test_project_path);
+
+    if (!data.is_cmake_re) {
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "CMakeLists.txt"));
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "Iconv-ad80b024-src" / "configure"));
+    }
+    BOOST_REQUIRE(fs::exists(overridden_FETCHCONTENT_BASE_DIR / "mathlib-build" / "CMakeCache.txt"));
+    BOOST_REQUIRE(fs::exists(overridden_FETCHCONTENT_BASE_DIR / "Iconv-adapter" / "CMakeLists.txt"));
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path);
+    BOOST_REQUIRE(fs::exists(overridden_FETCHCONTENT_BASE_DIR / "mathlib-install" / "lib" / "libMathFunctions.a"));
+    BOOST_REQUIRE(fs::exists(overridden_FETCHCONTENT_BASE_DIR / "Iconv-install" / "lib" / "libiconv.a"));
+  }
+
+  BOOST_DATA_TEST_CASE(HERMETIC_FETCHCONTENT_INSTALL_DIR_works, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_change_base_dir", data.is_cmake_re);
+    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h","lib.h"});
+
+    fs::path overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR = test_project_path / "test-installdir";
+    fs::create_directories(overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR);
+
+    run_command(
+      get_cmake_configure_command(test_project_path, data)
+      + " -DHERMETIC_FETCHCONTENT_INSTALL_DIR="s + overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR.generic_string(), test_project_path);
+
+    if (!data.is_cmake_re) {
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "CMakeLists.txt"));
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "Iconv-ad80b024-src" / "configure"));
+    }
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "mathlib-build" / "CMakeCache.txt"));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "Iconv-adapter" / "CMakeLists.txt"));
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path);
+    BOOST_REQUIRE(fs::exists(overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR / "mathlib-install" / "lib" / "libMathFunctions.a"));
+    BOOST_REQUIRE(fs::exists(overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR / "Iconv-install" / "lib" / "libiconv.a"));
+  }
+
+  BOOST_DATA_TEST_CASE(FETCHCONTENT_BASE_DIR_and_HERMETIC_FETCHCONTENT_INSTALL_DIR_combined, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_change_base_dir", data.is_cmake_re);
+    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h","lib.h"});
+
+    fs::path overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR = test_project_path / "test-installdir";
+    fs::create_directories(overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR);
+
+    fs::path overridden_FETCHCONTENT_BASE_DIR = test_project_path / "change_base";
+    fs::create_directories(overridden_FETCHCONTENT_BASE_DIR);
+
+    run_command(
+      get_cmake_configure_command(test_project_path, data)
+      + " -DHERMETIC_FETCHCONTENT_INSTALL_DIR="s + overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR.generic_string()
+      + " -DFETCHCONTENT_BASE_DIR="s + overridden_FETCHCONTENT_BASE_DIR.generic_string(), test_project_path);
+
+    if (!data.is_cmake_re) {
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "CMakeLists.txt"));
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "Iconv-ad80b024-src" / "configure"));
+    }
+    BOOST_REQUIRE(fs::exists(overridden_FETCHCONTENT_BASE_DIR / "mathlib-build" / "CMakeCache.txt"));
+    BOOST_REQUIRE(fs::exists(overridden_FETCHCONTENT_BASE_DIR / "Iconv-adapter" / "CMakeLists.txt"));
+
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path);
+
+    BOOST_REQUIRE(fs::exists(overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR / "mathlib-install" / "lib" / "libMathFunctions.a"));
+    BOOST_REQUIRE(fs::exists(overriden_HERMETIC_FETCHCONTENT_INSTALL_DIR / "Iconv-install" / "lib" / "libiconv.a"));
+  }
+}

--- a/test/test_project_templates/check_change_base_dir/CMakeLists.txt
+++ b/test/test_project_templates/check_change_base_dir/CMakeLists.txt
@@ -1,0 +1,61 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  "mathlib"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92"
+)
+
+FetchContent_MakeHermetic(
+  "mathlib"
+  HERMETIC_BUILD_SYSTEM cmake
+)
+
+HermeticFetchContent_MakeAvailableAtBuildTime("mathlib")
+
+FetchContent_Declare(
+  Iconv
+  GIT_REPOSITORY https://github.com/tipi-build/unittest-autotools-sample.git
+  GIT_TAG ad80b024eeda8f4c0a96eedf669dc453ed33a094 
+)
+
+FetchContent_MakeHermetic(
+  Iconv
+  HERMETIC_CMAKE_EXPORT_LIBRARY_DECLARATION 
+     [=[
+       add_library(Iconv::Iconv STATIC IMPORTED)
+       set_property(TARGET Iconv::Iconv PROPERTY IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/lib/libiconv.a")    
+       set_property(TARGET Iconv::Iconv PROPERTY INTERFACE_INCLUDE_DIRECTORIES @HFC_PREFIX_PLACEHOLDER@/include)
+     ]=]
+  HERMETIC_TOOLCHAIN_EXTENSION 
+    [=[
+        add_compile_definitions(
+          TIPI_TEAM=1
+          TIPI_TEAM_ZURICH
+          # TIPI_TEAM_LOCATION=ZURICH
+        )
+    ]=]
+
+  HERMETIC_BUILD_SYSTEM autotools
+)
+
+HermeticFetchContent_MakeAvailableAtBuildTime(Iconv)
+
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::MathFunctions MathFunctionscbrt::MathFunctionscbrt Iconv::Iconv)
+


### PR DESCRIPTION
Added test showing that you can move the build folder and install folder by forcing FETCHCONTENT_BASE_DIR .

Close : https://github.com/tipi-build/specs-cmake-re/issues/42

