### PR TITLE
 Fix cmake-re install issue + add unit tests for CUSTOM_INSTALL_TARGETS

### DIFF
--- a/cmake/HermeticFetchContent.cmake
+++ b/cmake/HermeticFetchContent.cmake
@@ -249,8 +249,12 @@ Commands
   a library export declaration that will enable Hermetic FetchContent to consume the targets
   as-if the project had provided a proper package configuration.
 
-  Note the use of the template variable ``@HFC_PREFIX_PLACEHOLDER@`` which will be replaced
-  with the final install prefix location when the library is consumed later on. 
+  Note the use of template variable :
+  - ``@HFC_SOURCE_DIR_PLACEHOLDER@`` which will be replaced with the source directory location when the library is consumed later on. 
+  - ``@HFC_BINARY_DIR_PLACEHOLDER@`` which will be replaced with the binaries directory location when the library is consumed later on.
+  - ``@HFC_PREFIX_PLACEHOLDER@`` which will be replaced with the final install prefix location when the library is consumed later on. 
+ 
+
 
   The following example shows how to define the ``Pcap::Pcap`` target properties required
   for Hermetic FetchContent to be able to construct a so-called "targets cache":

--- a/cmake/modules/hfc_cmake_register_content_build.cmake
+++ b/cmake/modules/hfc_cmake_register_content_build.cmake
@@ -104,8 +104,6 @@ function(hfc_cmake_register_content_build content_name)
     list(APPEND install_commands_list "${CMAKE_COMMAND} --install .")
   endif()
 
-  list(JOIN install_commands_list " && " install_command)
-  
   #
   # build the install done marker cleaner
   set(install_command_done_marker_cleaner "")
@@ -119,12 +117,13 @@ function(hfc_cmake_register_content_build content_name)
       string(APPEND install_command_done_marker_cleaner " ${found_marker_file}")
     endforeach()
 
-    string(APPEND install_command " && ${install_command_done_marker_cleaner}")
+    list(APPEND install_commands_list "${install_command_done_marker_cleaner}")
   endif()
 
-  # this marks this build as installed
-  string(APPEND install_command " && ${CMAKE_COMMAND} -E make_directory ${installed_marker_parent_path}")
-  string(APPEND install_command " && ${CMAKE_COMMAND} -E touch ${FN_ARG_HFC_INSTALL_MARKER_FILE}")
+  list(APPEND install_commands_list "${CMAKE_COMMAND} -E make_directory ${installed_marker_parent_path}")
+  list(APPEND install_commands_list "${CMAKE_COMMAND} -E touch ${FN_ARG_HFC_INSTALL_MARKER_FILE}")
+
+  list(JOIN install_commands_list " && " install_command)
 
   if (CMAKE_RE_PATH)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,6 +100,8 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/targets_cache_test.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/hermetic_dependency_make_executable_findable.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/goldilock_provisioning_test.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_source_build_hfc_prefix.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_CUSTOM_INSTALL_TARGETS.cpp
+++ b/test/check_CUSTOM_INSTALL_TARGETS.cpp
@@ -1,0 +1,37 @@
+#define BOOST_TEST_MODULE check_CUSTOM_INSTALL_TARGETS
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+ 
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+
+  BOOST_DATA_TEST_CASE(check_CUSTOM_INSTALL_TARGETS_works, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_CUSTOM_INSTALL_TARGETS", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+    write_simple_main(test_project_path,{"MathFunctions.h"});  
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "MyExample" ));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "mathlib-build" / "libMathFunctions.a"));
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "mathlib-build" / "libMathFunctionscbrt.a"));
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "mathlib-install" / "lib" / "libMathFunctionscbrt.a"));
+
+  
+  }
+
+}

--- a/test/check_source_build_hfc_prefix.cpp
+++ b/test/check_source_build_hfc_prefix.cpp
@@ -1,0 +1,46 @@
+#define BOOST_TEST_MODULE check_source_build_hfc_prefix
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+ 
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+
+  BOOST_DATA_TEST_CASE(check_source_build_hfc_prefix_works, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_source_build_hfc_prefix", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+
+
+    write_simple_main(test_project_path,{"file_only_in_source.hpp","file_only_in_build.hpp"});  
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "MyExample" ));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "mathlib-build" / "file_only_in_build.hpp"));
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "mathlib-build" / "file_only_in_source.hpp"));
+    if (!data.is_cmake_re){
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-c35bc46a-src" / "file_only_in_source.hpp" ));
+      BOOST_REQUIRE(!fs::exists(test_project_path / "thirdparty" / "cache" / "mathlib-c35bc46a-src" / "file_only_in_build.hpp" ));   
+    } else if(data.is_cmake_re){
+      // the read simlink is /usr/local/share/.tipi/vK.w/876340f-check_source_build_hfc_prefix.b/1e0a9df/bin
+      fs::path build_folder_mirror = fs::read_symlink(test_project_path / "build").parent_path().parent_path();
+      fs::path test_project_path_mirror = build_folder_mirror.parent_path() / build_folder_mirror.stem();
+      BOOST_REQUIRE(fs::exists(test_project_path_mirror / "thirdparty" / "cache" / "mathlib-c35bc46a-src" / "file_only_in_source.hpp" ));
+      BOOST_REQUIRE(!fs::exists(test_project_path_mirror / "thirdparty" / "cache" / "mathlib-c35bc46a-src" / "file_only_in_build.hpp" ));   
+    } 
+  }
+
+}

--- a/test/test_project_templates/check_CUSTOM_INSTALL_TARGETS/CMakeLists.txt
+++ b/test/test_project_templates/check_CUSTOM_INSTALL_TARGETS/CMakeLists.txt
@@ -1,0 +1,41 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
+set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  "mathlib"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "c35bc46a3bc0f6ed7b14e11d34602079a3d8ab83"
+)
+
+FetchContent_MakeHermetic(
+  "mathlib"
+  BUILD_TARGETS "MathFunctions"
+  CUSTOM_INSTALL_TARGETS "MathFunctions"
+  HERMETIC_BUILD_SYSTEM cmake
+  HERMETIC_CMAKE_EXPORT_LIBRARY_DECLARATION [=[
+    add_library(MathFunctions::MathFunctions STATIC IMPORTED)
+    set_property(TARGET MathFunctions::MathFunctions PROPERTY IMPORTED_LOCATION "@HFC_BINARY_DIR_PLACEHOLDER@/libMathFunctions.a")
+    set_property(TARGET MathFunctions::MathFunctions PROPERTY INTERFACE_INCLUDE_DIRECTORIES @HFC_SOURCE_DIR_PLACEHOLDER@)
+]=]
+)
+
+HermeticFetchContent_MakeAvailableAtBuildTime("mathlib")
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::MathFunctions)
+

--- a/test/test_project_templates/check_source_build_hfc_prefix/CMakeLists.txt
+++ b/test/test_project_templates/check_source_build_hfc_prefix/CMakeLists.txt
@@ -1,0 +1,39 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
+set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  "mathlib"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "c35bc46a3bc0f6ed7b14e11d34602079a3d8ab83"
+)
+
+FetchContent_MakeHermetic(
+  "mathlib"
+  HERMETIC_BUILD_SYSTEM cmake
+  HERMETIC_CMAKE_EXPORT_LIBRARY_DECLARATION [=[
+    add_library(MathFunctions::headers INTERFACE IMPORTED)
+    set_property(TARGET MathFunctions::headers PROPERTY INTERFACE_INCLUDE_DIRECTORIES @HFC_SOURCE_DIR_PLACEHOLDER@)
+    set_property(TARGET MathFunctions::headers APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES @HFC_BINARY_DIR_PLACEHOLDER@)
+]=]
+)
+
+HermeticFetchContent_MakeAvailableAtBuildTime("mathlib")
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::headers)
+


### PR DESCRIPTION
We delivered a feature tested in an example for `CUSTOM_INSTALL_TARGETS` but did not include unit tests for it. This commit adds missing tests and documentation.

- Add unit tests for `CUSTOM_INSTALL_TARGETS`
- Add unit tests for new HFC placeholders
- Improve documentation
- Fix `cmake-re` install issue, prevent `&& &&` when no install target exists

Change-Id: Ibfe949cb1bc48266526e5d810e777f59ededc3

Close: https://github.com/tipi-build/specs-cmake-re/issues/52