### PR TITLE
Improved FORCE_SYSTEM_<content-name> behavior

### DIFF
--- a/cmake/modules/hfc_autotools_restore_or_configure.cmake
+++ b/cmake/modules/hfc_autotools_restore_or_configure.cmake
@@ -211,7 +211,7 @@ function(hfc_autotools_restore_or_configure content_name)
   cmake_language(CALL ${FN_ARG_CMAKE_ADAPTER_GENERATOR_FN}_get_install_target install_target_name)
 
   # Toolchain to forward arguments
-  set(proxy_toolchain_path "${HERMETIC_FETCHCONTENT_INSTALL_DIR}/${content_name}-toolchain/hfc_hermetic_proxy_toolchain.cmake")
+  hfc_get_content_proxy_toolchain_path(${content_name} proxy_toolchain_path)
   hfc_generate_cmake_proxy_toolchain(${content_name}
     # PROJECT_DEPENDENCIES not passed : Autotools cannot have dependencies, it doesn't "cmake-find_package"
     PROJECT_TOOLCHAIN_EXTENSION "${FN_ARG_PROJECT_TOOLCHAIN_EXTENSION}"

--- a/cmake/modules/hfc_cmake_restore_or_configure.cmake
+++ b/cmake/modules/hfc_cmake_restore_or_configure.cmake
@@ -77,9 +77,8 @@ function(hfc_cmake_restore_or_configure content_name)
     )
   endif()
 
-  set(proxy_toolchain_dir "${HERMETIC_FETCHCONTENT_INSTALL_DIR}/${content_name}-toolchain")
-  set(proxy_toolchain_path "${HERMETIC_FETCHCONTENT_INSTALL_DIR}/${content_name}-toolchain/hfc_hermetic_proxy_toolchain.cmake")
-
+  hfc_get_content_proxy_toolchain_dir(${content_name} proxy_toolchain_dir)
+  hfc_get_content_proxy_toolchain_path(${content_name} proxy_toolchain_path)
   file(LOCK ${proxy_toolchain_dir} DIRECTORY GUARD FUNCTION)
 
   hfc_generate_cmake_proxy_toolchain(${content_name}

--- a/cmake/modules/hfc_generate_cmake_proxy_toolchain.cmake
+++ b/cmake/modules/hfc_generate_cmake_proxy_toolchain.cmake
@@ -3,6 +3,16 @@ include_guard()
 include(hfc_log)
 include(hfc_targets_cache_common)
 
+function(hfc_get_content_proxy_toolchain_dir content_name OUT_result)
+  set(${OUT_result} "${FETCHCONTENT_BASE_DIR}/${content_name}-toolchain" PARENT_SCOPE)
+endfunction()
+
+function(hfc_get_content_proxy_toolchain_path content_name OUT_result)
+  hfc_get_content_proxy_toolchain_dir("${content_name}" proxy_toolchain_dir)
+  set(${OUT_result} "${proxy_toolchain_dir}/hfc_hermetic_proxy_toolchain.cmake" PARENT_SCOPE)
+endfunction()
+
+
 #[=======================================================================[.rst:
 hfc_generate_cmake_proxy_toolchain
 ------------------------------------------------------------------------------------------

--- a/cmake/modules/hfc_targets_cache_create.cmake
+++ b/cmake/modules/hfc_targets_cache_create.cmake
@@ -232,7 +232,7 @@ endfunction()
 #   LOAD_TARGETS_CMAKE <cmake code to eval for loading targets>
 #   CACHE_DESTINATION_FILE <path>         # path to the target info cache to write. Parent directory will be created if not already present. Destination file will be overwritten if present
 # )
-function(hfc_targets_cache_create_isolated)  
+function(hfc_targets_cache_create_isolated content_name)  
 
   # arguments parsing
   set(options "")
@@ -252,11 +252,19 @@ function(hfc_targets_cache_create_isolated)
 
   file(MAKE_DIRECTORY "${tmp_proj_dir}")
 
+  # make sure we have the same enabled languages if the FORCE_SYSTEM_<content-name>
+  set(TEMPLATE_ENABLE_LANGUAGES "NONE")
+  if(FORCE_SYSTEM_${content_name})
+    get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    set(TEMPLATE_ENABLE_LANGUAGES ${languages})
+  endif()
+
   block(SCOPE_FOR VARIABLES PROPAGATE 
     HERMETIC_FETCHCONTENT_ROOT_DIR 
     FN_ARG_LOAD_TARGETS_CMAKE 
     FN_ARG_CACHE_DESTINATION_FILE 
     FN_ARG_CREATE_TARGET_ALIASES
+    TEMPLATE_ENABLE_LANGUAGES
   )
     set(HERMETIC_FETCHCONTENT_ROOT_DIR "${HERMETIC_FETCHCONTENT_ROOT_DIR}")
     set(LOAD_TARGETS_CMAKE "${FN_ARG_LOAD_TARGETS_CMAKE}")
@@ -317,6 +325,7 @@ function(hfc_targets_cache_create_from_export_declaration content_name)
   hfc_log_debug("Generating targets cache for ${content_name} from export declaration at ${${FN_ARG_OUT_TARGETS_CACHE_FILE}}")
 
   hfc_targets_cache_create_isolated(
+    ${content_name}
     LOAD_TARGETS_CMAKE "[==[${FN_ARG_CMAKE_EXPORT_LIBRARY_DECLARATION}]==]"
     TOOLCHAIN_FILE ${FN_ARG_TOOLCHAIN_FILE}
     CACHE_DESTINATION_FILE "${${FN_ARG_OUT_TARGETS_CACHE_FILE}}"

--- a/cmake/templates/create_imported_cmake_targets_cache.CMakeLists.txt.in
+++ b/cmake/templates/create_imported_cmake_targets_cache.CMakeLists.txt.in
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.27.0)
-project(create_imported_cmake_targets_cache LANGUAGES NONE)
+project(create_imported_cmake_targets_cache LANGUAGES @TEMPLATE_ENABLE_LANGUAGES@)
 
 list(APPEND CMAKE_MODULE_PATH "@HERMETIC_FETCHCONTENT_ROOT_DIR@")
 list(APPEND CMAKE_MODULE_PATH "@HERMETIC_FETCHCONTENT_ROOT_DIR@/modules")

--- a/test/check_openssl_build_system.cpp
+++ b/test/check_openssl_build_system.cpp
@@ -55,6 +55,7 @@ namespace hfc::test {
     BOOST_REQUIRE(!fs::exists(test_project_path / "thirdparty" / "cache" / "openssl-src"));
     BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "OpenSSL-install" / "lib" / "libssl.a"  ));
     BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "OpenSSL-install" / "lib" / "libcrypto.a"  ));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "hermetic_targetcaches" / "OpenSSL.cmake"));
 
     std::string ninja_output = run_command(cmake_build_command, test_project_path);
     BOOST_REQUIRE(boost::contains(ninja_output, "ninja: no work to do"));

--- a/test/test_project_templates/hfc_targets_cache/FORCE_SYSTEM_findModuleforwarding/CMakeLists.txt
+++ b/test/test_project_templates/hfc_targets_cache/FORCE_SYSTEM_findModuleforwarding/CMakeLists.txt
@@ -1,0 +1,62 @@
+
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  "${CMAKE_CURRENT_SOURCE_DIR}/projectCmakeModules" # this!
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+
+# this is set by the test program, just making sure we have a value
+# when set to ON this should ensure we get to use the FindIconv.cmake module found under ./projectCmakeModules/
+if(NOT DEFINED FORCE_SYSTEM_Iconv)
+  message(FATAL_ERROR "FORCE_SYSTEM_Iconv not defined")
+endif()
+
+# test if data from this build's CMakeCache get forwarded, there's a message() outputtting TESTDATA_INJECTED in our custom findIconv.cmake
+# and the test checks if it can find that info
+set(HERMETIC_FETCHCONTENT_FORWARDED_CMAKE_VARIABLES "TESTDATA_INJECTED;CMAKE_BUILD_TYPE;CMAKE_CXX_STANDARD;CMAKE_CXX_STANDARD_REQUIRED") 
+
+FetchContent_Declare(
+  Iconv
+  GIT_REPOSITORY "https://github.com/tipi-build/unittest-autotools-sample.git"
+  GIT_TAG "ad80b024eeda8f4c0a96eedf669dc453ed33a094"
+)
+
+FetchContent_MakeHermetic(
+  Iconv
+  HERMETIC_CMAKE_EXPORT_LIBRARY_DECLARATION 
+  [=[
+    add_library(Iconv::Iconv STATIC IMPORTED)
+    set_property(TARGET Iconv::Iconv PROPERTY IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/lib/libiconv.a")    
+    set_property(TARGET Iconv::Iconv PROPERTY INTERFACE_INCLUDE_DIRECTORIES @HFC_PREFIX_PLACEHOLDER@/include)
+  ]=]
+  HERMETIC_BUILD_SYSTEM autotools
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime("Iconv")
+
+
+if(NOT TARGET Iconv::Iconv)
+  message(FATAL_ERROR "Could not find target Iconv::Iconv")
+endif()
+
+# our custom findIconv defines this so we can be sure it worked...
+get_target_property(iconv_LABELS Iconv::Iconv LABELS)
+
+if(NOT iconv_LABELS STREQUAL "LABEL_BY_HFC")
+  message(FATAL_ERROR "iconv_LABELS not set as expected... it seems I iconv was not provided through our custom findIconv module")
+endif()
+
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE Iconv::Iconv)

--- a/test/test_project_templates/hfc_targets_cache/FORCE_SYSTEM_findModuleforwarding/projectCmakeModules/FindIconv.cmake
+++ b/test/test_project_templates/hfc_targets_cache/FORCE_SYSTEM_findModuleforwarding/projectCmakeModules/FindIconv.cmake
@@ -1,0 +1,7 @@
+message(STATUS "Our custom findmodule was executed TESTDATA_INJECTED=${TESTDATA_INJECTED}")
+
+# just let cmake do the actual work...
+include(${CMAKE_ROOT}/Modules/FindIconv.cmake)
+
+# mark this so we know it's from us!
+set_target_properties(Iconv::Iconv PROPERTIES LABELS "LABEL_BY_HFC")

--- a/test/test_project_templates/hfc_targets_cache/FORCE_SYSTEM_findModuleforwarding/simple_example.cpp
+++ b/test/test_project_templates/hfc_targets_cache/FORCE_SYSTEM_findModuleforwarding/simple_example.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Improve the behavior of hfc_make_available_single when FORCE_SYSTEM_<content-name> is set for a given dependency by forcing find_xxx to use the system root for its search.
Additionally the system was made more reliable by ensuring that a proxy toolchain is generate to forward necessary project information in addition to enabling the same CMAKE_LANGUAGEs as the invoking project.
Furthermore the forwarding of the main project's CMAKE_MODULE_PATH information to the proxy toolchain of the project generating the target cache for a FORCE_SYSTEM_<content-name> was implemented to improve transparency of behavior.

Co-authored-by: Damien Buhl

Change-Id: Ia55263361f376fb40a7c4b66dc559c7bbc931feb