### PR TITLE
Fix HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL

### DIFF
--- a/cmake/modules/hfc_initialize.cmake
+++ b/cmake/modules/hfc_initialize.cmake
@@ -305,13 +305,10 @@ function(hfc_initialize HFC_ROOT_DIR)
 
   if(NOT hfc_initialized)
     
-    if (NOT DEFINED CACHE{HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL})
-      set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing build" FORCE)
-    endif()
-    
-    if (NOT DEFINED CACHE{HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL})
-      set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing sources after install" FORCE)
-    endif()
+    # Note : We don't set the following defaults on purpose as unset it will be evaluated OFF
+    #        This allows also overriding with a pure scope variable and not CACHE
+    # set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing build")
+    # set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing sources after install")
 
     set_property(GLOBAL PROPERTY HERMETIC_FETCHCONTENT_INITIALIZED ON)
     set(HERMETIC_FETCHCONTENT_ROOT_DIR "${HFC_ROOT_DIR}" CACHE INTERNAL "Root directory of Hermetic_FetchContent")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,6 +103,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/check_source_build_hfc_prefix.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_delete_build_folder.cpp
+++ b/test/check_delete_build_folder.cpp
@@ -1,0 +1,82 @@
+#define BOOST_TEST_MODULE check_delete_build_folder
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+ 
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+
+  BOOST_DATA_TEST_CASE(check_if_we_can_remove_build_and_source_folder, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_install-reuse", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h"});
+    write_simple_main(test_project_path,{}, "simple_main.cpp");
+
+    auto content = pre::file::to_string(project_toolchain.generic_string());
+    content += "\n  set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL ON CACHE BOOL \"\") \n set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL ON CACHE BOOL \"\")\n";
+    pre::file::from_string(project_toolchain.generic_string(), content);
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "project-cmake-simple-build" / "CMakeCache.txt"));
+    if(!data.is_cmake_re){
+      BOOST_REQUIRE(!fs::exists(test_project_path / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt"));
+    }else if(data.is_cmake_re){
+      BOOST_REQUIRE(!fs::exists(get_mirror_test_project_path(test_project_path) / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt" ));
+    } 
+  }
+
+  BOOST_DATA_TEST_CASE(check_if_we_can_keep_build_and_source_folder, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_install-reuse", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h"});
+    write_simple_main(test_project_path,{}, "simple_main.cpp");
+
+    auto content = pre::file::to_string(project_toolchain.generic_string());
+    content += "\n  set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE BOOL \"\") \n set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE BOOL \"\")\n";
+    pre::file::from_string(project_toolchain.generic_string(), content);
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "project-cmake-simple-build" / "CMakeCache.txt"));
+    if(!data.is_cmake_re){
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt"));
+    }else if(data.is_cmake_re){
+      BOOST_REQUIRE(fs::exists(get_mirror_test_project_path(test_project_path) / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt" ));
+    } 
+  }
+
+  BOOST_DATA_TEST_CASE(check_if_we_can_keep_build_and_source_folder_without_define_value, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_install-reuse", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h"});
+    write_simple_main(test_project_path,{}, "simple_main.cpp");
+
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "project-cmake-simple-build" / "CMakeCache.txt"));
+    if(!data.is_cmake_re){
+      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt"));
+    }else if(data.is_cmake_re){
+      BOOST_REQUIRE(fs::exists(get_mirror_test_project_path(test_project_path) / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt" ));
+    } 
+  }
+}

--- a/test/test_project.hpp
+++ b/test/test_project.hpp
@@ -210,4 +210,9 @@ namespace hfc::test {
     outfile << "\n" << to_append << "\n" << std::flush;
     outfile.close();
   }
+
+  inline fs::path get_mirror_test_project_path(fs::path test_project_path ){
+    fs::path build_folder_mirror = fs::read_symlink(test_project_path / "build").parent_path().parent_path();
+    return build_folder_mirror.parent_path() / build_folder_mirror.stem();
+  }
 }


### PR DESCRIPTION
Keep the build and source directories of dependencies by default 
Add a test to verify the deletion of build and source directories 
Related : https://github.com/tipi-build/hfc/pull/9#pullrequestreview-2586840884

Change-Id: Id908c2c5aa827a0eabbe8459079d46055766bf
