### PR TITLE
 Reducing noise generated by hfc_git_helpers

### DIFF
--- a/cmake/modules/hfc_git_helpers.cmake
+++ b/cmake/modules/hfc_git_helpers.cmake
@@ -50,10 +50,6 @@ function(git_exec)
         set(execute_process_arg_COMMAND_ERROR_IS_FATAL COMMAND_ERROR_IS_FATAL ${FN_ARG_COMMAND_ERROR_IS_FATAL})
     endif()
 
-    if(FN_ARG_OUT_RESULT)
-        set(execute_process_arg_OUTPUT_VARIABLE OUTPUT_VARIABLE cmd_output OUTPUT_STRIP_TRAILING_WHITESPACE)
-    endif()
-
     if(FN_ARG_OUT_RETURN_CODE)
         set(execute_process_arg_RESULT_VARIABLE RESULT_VARIABLE cmd_retcode)
     endif()
@@ -68,11 +64,12 @@ function(git_exec)
 
     execute_process(COMMAND ${shell} "${FN_ARG_COMMAND}"
         WORKING_DIRECTORY "${FN_ARG_WORKING_DIRECTORY}"
-        ECHO_OUTPUT_VARIABLE
+        OUTPUT_VARIABLE cmd_output OUTPUT_STRIP_TRAILING_WHITESPACE
         ${execute_process_arg_COMMAND_ERROR_IS_FATAL}
         ${execute_process_arg_RESULT_VARIABLE}
-        ${execute_process_arg_OUTPUT_VARIABLE}
     )
+
+    hfc_log_debug("Output of ${FN_ARG_COMMAND}: ${cmd_output}")
 
     if(FN_ARG_OUT_RESULT)
         set(${FN_ARG_OUT_RESULT} "${cmd_output}" PARENT_SCOPE)

--- a/cmake/modules/hfc_make_available_single.cmake
+++ b/cmake/modules/hfc_make_available_single.cmake
@@ -238,9 +238,39 @@ function(hfc_make_available_single content_name build_at_configure_time)
   hfc_create_restore_prefixes(${content_name} ${__PARAMS_BINARY_DIR} ${cmake_contentInstallPath})
 
   # register the content/project specific populate() function
-  hfc_populate_project_declare(${content_name})  
+  set(origin_with_resolved_patch "")
 
+  hfc_populate_project_declare(${content_name})  
   hfc_determine_cache_id(${content_name})
+
+  if(__PARAMS_HERMETIC_PREPATCHED_RESOLVER)
+
+    hfc_evaluate_prepatched_resolver(
+      OUT_VAR_PREFIX prepatched_
+      HERMETIC_PREPATCHED_RESOLVER "${__PARAMS_HERMETIC_PREPATCHED_RESOLVER}"
+
+      URL "${__PARAMS_URL}"
+      URL_HASH "${__PARAMS_URL_HASH}"
+      GIT_REPOSITORY "${__PARAMS_GIT_REPOSITORY}"
+      GIT_TAG "${__PARAMS_GIT_TAG}"
+      GIT_SUBMODULES "${__PARAMS_GIT_SUBMODULES}"
+      SOURCE_DIR "${__PARAMS_SOURCE_DIR}"
+    )
+
+    if(prepatched_RESOLVED_PATCH)
+      if(prepatched_URL)
+        set(origin_with_resolved_patch "${prepatched_URL}")
+      elseif(prepatched_GIT_REPOSITORY)
+        set(origin_with_resolved_patch "${prepatched_GIT_REPOSITORY}")
+      endif()
+    endif()
+
+  endif()
+
+  if(origin_with_resolved_patch)
+    # Use the prepatched origin as cache-key
+    set (${content_name}_origin "${origin_with_resolved_patch}")
+  endif()
 
   # select the project scheme based on build system name info
   if(NOT DEFINED __PARAMS_HERMETIC_BUILD_SYSTEM)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,6 +104,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_prepatch_resolver.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_prepatch_resolver.cpp
+++ b/test/check_prepatch_resolver.cpp
@@ -1,0 +1,41 @@
+#define BOOST_TEST_MODULE check_prepatch_resolver
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+  using namespace std::string_literals;
+
+  BOOST_DATA_TEST_CASE(check_that_resolver_is_used_and_origin_changed, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path template_path = prepare_project_to_be_tested("check_prepatch_resolver", data.is_cmake_re);
+    write_simple_main(template_path,{"MathFunctions.h", "MathFunctionscbrt.h", "MathFunctionsmultiplybytwo.h"});
+
+    std::string cmake_configure_command = get_cmake_configure_command(template_path, data);    
+    run_command(cmake_configure_command, template_path);
+    run_command(get_cmake_build_command(template_path, data), template_path);
+
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "MyExample" ));
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "_deps" / "mathlib-install" / "lib" / "libMathFunctions.a"));
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "_deps" / "mathlib-install" / "lib" / "libMathFunctionscbrt.a"));
+    BOOST_REQUIRE(fs::exists(template_path / "build" / "_deps" / "mathlib-install" / "lib" / "libMathFunctionsmultiplybytwo.a"));
+
+
+    if(data.is_cmake_re){
+      fs::path mathlib_install_path = template_path / "build" / "_deps" / "mathlib-install";
+      fs::path mathlib_install_path_no_symlink = fs::read_symlink(mathlib_install_path);
+      BOOST_REQUIRE(boost::contains(mathlib_install_path_no_symlink.generic_string() ,"unit-test-cmake-template-2libs-simulation-prepatch"));
+    }
+  }
+}

--- a/test/test_project_templates/check_prepatch_resolver/CMakeLists.txt
+++ b/test/test_project_templates/check_prepatch_resolver/CMakeLists.txt
@@ -1,0 +1,42 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
+set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  "mathlib"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92"
+  PATCH_COMMAND "${CMAKE_COMMAND} -E environment"
+)
+
+FetchContent_MakeHermetic(
+  "mathlib"
+  HERMETIC_BUILD_SYSTEM cmake
+  HERMETIC_PREPATCHED_RESOLVER [=[
+  if(${GIT_TAG} STREQUAL "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92")
+     set(GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs-simulation-prepatch")
+     set(GIT_TAG "7b661a3c99164648f2209b811cea4d12b9858e67")
+     set(RESOLVED_PATCH TRUE)
+  endif()
+ ]=]
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime("mathlib")
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::MathFunctions MathFunctionscbrt::MathFunctionscbrt MathFunctionsmultiplybytwo::MathFunctionsmultiplybytwo)
+


### PR DESCRIPTION
HermeticFetchContent v1.0.13 : Reducing noise generated by hfc_git_helpers

Removing non-debug output that was generated by hfc_git_helpers. More useful output is available when debug logging is enabled.

Change-Id: Ibf6409ba9a218430bfa51676d693aa2dfd624f18