### PR TITLE
Fix race condition in SBOM generation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
+++ b/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
@@ -1,10 +1,9 @@
 ---
-name: [HFC] Release
-about: Checklist to make a release
+name: "[HFC] Release"
+about: "Checklist to make a release"
 title: "[HFC][RELEASE] v0.0."
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 # How to make a release ?

--- a/cmake/modules/hfc_sbom.cmake
+++ b/cmake/modules/hfc_sbom.cmake
@@ -233,9 +233,10 @@ message(STATUS \"===SBOM===\")
 message(STATUS \"${output_destination_path}\")
 	")
 
+    __get_env_shell_command(shell)
     add_custom_target(hfc_generate_sbom
       COMMENT "Generate the project's SBOM"
-      COMMAND ${CMAKE_COMMAND} "-P ${generate_sbom_script}"
+      COMMAND ${shell} "-c" "${HERMETIC_FETCHCONTENT_goldilock_BIN} --lockfile ${output_destination_path}.lock -- ${CMAKE_COMMAND} -P ${generate_sbom_script}"
     )
 
 endfunction()


### PR DESCRIPTION
Fix race condition in hfc_generate_sbom target when run in high concurrency situations (especially on I/O congested systems) where overlapping write could happen resulting in some CMake execution errors.

Change-Id: I7f22a8996e048ae6c2164eb55a5d433ac00f363e