### PR TITLE
[HFC][RELEASE] v0.0.14 : Fix race condition in SBOM generation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
+++ b/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
@@ -1,10 +1,9 @@
 ---
-name: [HFC] Release
-about: Checklist to make a release
+name: "[HFC] Release"
+about: "Checklist to make a release"
 title: "[HFC][RELEASE] v0.0."
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 # How to make a release ?

--- a/cmake/modules/hfc_sbom.cmake
+++ b/cmake/modules/hfc_sbom.cmake
@@ -233,9 +233,10 @@ message(STATUS \"===SBOM===\")
 message(STATUS \"${output_destination_path}\")
 	")
 
+    __get_env_shell_command(shell)
     add_custom_target(hfc_generate_sbom
       COMMENT "Generate the project's SBOM"
-      COMMAND ${CMAKE_COMMAND} "-P ${generate_sbom_script}"
+      COMMAND ${shell} "-c" "${HERMETIC_FETCHCONTENT_goldilock_BIN} --lockfile ${output_destination_path}.lock -- ${CMAKE_COMMAND} -P ${generate_sbom_script}"
     )
 
 endfunction()


### PR DESCRIPTION
# How to make a release ?
HFC is a source package in that regard we don't want to have a special workflow transforming the sources or have the sources be different when released than when edited and tested.

In that regard we will make every merged-commit releasable.

- [x] Check that every commit in the main branch should read as follow : 

```
HermeticFetchContent v1.0.X : <TITLE>
<OR> CONFIG : <TITLE>
<OR> DOC : <TITLE>
<OR> TEST : <TITLE>

<summary...>

CHANGELOG

- User Facing Change Description

Change-Id: <gerrit-compatible-change-id>
```

## Pre-Release
- [x] Create a `release/v1.0.X` integration branch
  - [x] Target all PRs that should be in the release to this `release/v1.0.X` branch
  - [x] Rebase features PRs into `release/v1.0.X` with GH
    - Each feature should be one commit following template above
    - Each feature should have CI status passing

## Release scope : Rebase into current PR
- [x] https://github.com/tipi-build/hfc/pull/17


## Full-Release
- [ ] Test with Canary projects
  - [ ] canary-big
      - [ ] plain cmake (@pysco68)
      - [ ] cmake-re (@daminetreg)
  - [x] canary-medium
    - [x] plain cmake (@pysco68)
    - [ ] cmake-re
- [ ] Take the `release/v1.0.X` and **fast-forward** it in main
    - [ ] `git checkout main && git pull origin main --ff-only && git merge release/v1.0.X --ff-only` 