### PR TITLE
[RC] HermeticFetchContent v1.0.14...16 : parallel SBOM generation & BUILD_TARGETS fixes and test suite 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
+++ b/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
@@ -1,10 +1,9 @@
 ---
-name: [HFC] Release
-about: Checklist to make a release
+name: "[HFC] Release"
+about: "Checklist to make a release"
 title: "[HFC][RELEASE] v0.0."
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 # How to make a release ?

--- a/cmake/modules/hfc_cmake_register_content_build.cmake
+++ b/cmake/modules/hfc_cmake_register_content_build.cmake
@@ -100,7 +100,7 @@ function(hfc_cmake_register_content_build content_name)
 
   endif()
 
-  if ("${FN_ARG_CUSTOM_INSTALL_TARGETS}" STREQUAL "")
+  if (NOT FN_ARG_BUILD_TARGETS AND (NOT FN_ARG_CUSTOM_INSTALL_TARGETS))
     list(APPEND install_commands_list "${CMAKE_COMMAND} --install .")
   endif()
 

--- a/cmake/modules/hfc_sbom.cmake
+++ b/cmake/modules/hfc_sbom.cmake
@@ -233,9 +233,10 @@ message(STATUS \"===SBOM===\")
 message(STATUS \"${output_destination_path}\")
 	")
 
+    __get_env_shell_command(shell)
     add_custom_target(hfc_generate_sbom
       COMMENT "Generate the project's SBOM"
-      COMMAND ${CMAKE_COMMAND} "-P ${generate_sbom_script}"
+      COMMAND ${shell} "-c" "${HERMETIC_FETCHCONTENT_goldilock_BIN} --lockfile ${output_destination_path}.lock -- ${CMAKE_COMMAND} -P ${generate_sbom_script}"
     )
 
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/hermetic_dependency_make_executable_findable.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/goldilock_provisioning_test.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_source_build_hfc_prefix.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_BUILD_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"

--- a/test/check_BUILD_TARGETS.cpp
+++ b/test/check_BUILD_TARGETS.cpp
@@ -1,0 +1,35 @@
+#define BOOST_TEST_MODULE check_BUILD_TARGETS
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+ 
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+
+  BOOST_DATA_TEST_CASE(check_CUSTOM_INSTALL_TARGETS_works, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_BUILD_TARGETS", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "another-component"));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "some-component"));
+
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "yet-another-component"));
+  
+  }
+
+}

--- a/test/test_project_templates/check_BUILD_TARGETS/CMakeLists.txt
+++ b/test/test_project_templates/check_BUILD_TARGETS/CMakeLists.txt
@@ -1,0 +1,56 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  check_BUILD_TARGETS
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  components
+  GIT_REPOSITORY https://github.com/tipi-build/unit-test-cmake-install-components.git
+  GIT_TAG        bbe53f7fcf2824933bd2ef25dfb801b68723cd3a
+)
+
+FetchContent_MakeHermetic(
+  components 
+  
+  BUILD_TARGETS "some-component;another-component"
+  
+  HERMETIC_CMAKE_EXPORT_LIBRARY_DECLARATION  [=[
+    add_executable(some-component IMPORTED )
+    set_target_properties(some-component PROPERTIES 
+      IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/bin/some-component")
+    add_executable(another-component IMPORTED )
+    set_target_properties(another-component PROPERTIES 
+      IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/bin/another-component")
+  ]=]  
+
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime(components)
+
+get_target_property(some_component_LOCATION some-component IMPORTED_LOCATION)
+get_target_property(another_component_LOCATION another-component IMPORTED_LOCATION)
+
+cmake_path(GET some_component_LOCATION PARENT_PATH components_install_bin_folder)
+
+if(NOT EXISTS "${some_component_LOCATION}")
+  message(FATAL_ERROR "HFC didn't install requested components in BUILD_TARGETS: ${some_component_LOCATION}!")
+endif()
+
+if(NOT EXISTS "${another_component_LOCATION}")
+  message(FATAL_ERROR "HFC didn't install requested components in BUILD_TARGETS: ${another_component_LOCATION}!")
+endif()
+
+if(EXISTS "${components_install_bin_folder}/yet-another-component")
+  message(FATAL_ERROR "HFC installed all components but BUILD_TARGETS was provided !")
+endif()


### PR DESCRIPTION
With the introduction of CUSTOM_INSTALL_TARGETS new parameter in
v1.0.6 (https://github.com/tipi-build/hfc/commit/620edfc824b94dfe9793a833a5e164ecd4c5d32e) the projects configured
solely with BUILD_TARGETS were now installing everything even though they
only built a subset of their targets, leading to installation failures.

This restablishes the former behaviour of BUILD_TARGETS to install only
the CMake `install(COMPONENTS)` named the same as the BUILD_TARGETS.

Change-Id: Ia6c80ba0cf9be52580fcd2ec0fa4ff42a2798a42

# Release Checklist
HFC is a source package in that regard we don't want to have a special workflow transforming the sources or have the sources be different when released than when edited and tested.

In that regard we will make every merged-commit releasable.

- [ ] Check that every commit in the main branch should read as follow : 

```
HermeticFetchContent v1.0.X : <TITLE>
<OR> CONFIG : <TITLE>
<OR> DOC : <TITLE>
<OR> TEST : <TITLE>

<summary...>

CHANGELOG

- User Facing Change Description

Change-Id: <gerrit-compatible-change-id>
```

## Pre-Release
- [ ] Create a `release/v1.0.X` integration branch
  - [ ] Target all PRs that should be in the release to this `release/v1.0.X` branch
  - [ ] Rebase features PRs into `release/v1.0.X` with GH
    - Each feature should be one commit following template above
    - Each feature should have CI status passing

## Release scope : Rebase into current PR
- [x] #18 
- [x] BUILD_TARGETS fixes and test suite 
- [ ] #21 

## Full-Release
- [x] Test with Canary projects
  - [x] canary-big
    - [x] cmake (@Lambourl  linux ) https://tipibuild.slack.com/archives/C055MS3DG92/p1738867862927959
    - [x] cmake (@daminetreg macos ) https://tipibuild.slack.com/archives/C055MS3DG92/p1738871400151179
    - [x] cmake-re (@daminetreg) https://tipibuild.slack.com/archives/C055MS3DG92/p1738877379991019
  - [x] canary-medium 
      - [x] cmake (@Lambourl) https://tipibuild.slack.com/archives/C055MS3DG92/p1738867728861479
      - [x] cmake-re (@Lambourl) https://tipibuild.slack.com/archives/C055MS3DG92/p1738867728861479
- [ ] Take the `release/v1.0.16` and **fast-forward** it in main
    - [ ] `git checkout main && git pull origin main --ff-only && git pull origin release/v1.0.16 --ff-only` 
    - [ ] Reset after pushing to main release/v1.0.15 to actual v1.0.15.