### PR TITLE
Add support for shallow clones to populate

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
+++ b/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
@@ -1,10 +1,9 @@
 ---
-name: [HFC] Release
-about: Checklist to make a release
+name: "[HFC] Release"
+about: "Checklist to make a release"
 title: "[HFC][RELEASE] v0.0."
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 # How to make a release ?

--- a/cmake/modules/hfc_cmake_register_content_build.cmake
+++ b/cmake/modules/hfc_cmake_register_content_build.cmake
@@ -100,7 +100,7 @@ function(hfc_cmake_register_content_build content_name)
 
   endif()
 
-  if ("${FN_ARG_CUSTOM_INSTALL_TARGETS}" STREQUAL "")
+  if (NOT FN_ARG_BUILD_TARGETS AND (NOT FN_ARG_CUSTOM_INSTALL_TARGETS))
     list(APPEND install_commands_list "${CMAKE_COMMAND} --install .")
   endif()
 

--- a/cmake/modules/hfc_populate_project.cmake
+++ b/cmake/modules/hfc_populate_project.cmake
@@ -98,6 +98,7 @@ function(hfc_populate_project_declare content_name)
       GIT_REPOSITORY 
       GIT_TAG
       GIT_SUBMODULES
+      GIT_SHALLOW
       SOURCE_DIR 
       BUILD_IN_SOURCE_TREE
       SOURCE_SUBDIR
@@ -261,6 +262,10 @@ function(hfc_populate_project_declare content_name)
     elseif(FN_ARG_PATCH_COMMAND)
       list(APPEND populate_args "PATCH_COMMAND" "${FN_ARG_PATCH_COMMAND}")
       list(APPEND populate_args "UPDATE_DISCONNECTED" "1")  # avoid issues with repeated builds, which would "repatch"
+    endif()
+
+    if(FN_ARG_GIT_SHALLOW) 
+      list(APPEND populate_args "GIT_SHALLOW" ${FN_ARG_GIT_SHALLOW})
     endif()
     
     # we used to fix issues that could occur if the sources are missing but the stamp file were still around

--- a/cmake/modules/hfc_sbom.cmake
+++ b/cmake/modules/hfc_sbom.cmake
@@ -233,9 +233,10 @@ message(STATUS \"===SBOM===\")
 message(STATUS \"${output_destination_path}\")
 	")
 
+    __get_env_shell_command(shell)
     add_custom_target(hfc_generate_sbom
       COMMENT "Generate the project's SBOM"
-      COMMAND ${CMAKE_COMMAND} "-P ${generate_sbom_script}"
+      COMMAND ${shell} "-c" "${HERMETIC_FETCHCONTENT_goldilock_BIN} --lockfile ${output_destination_path}.lock -- ${CMAKE_COMMAND} -P ${generate_sbom_script}"
     )
 
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/hermetic_dependency_make_executable_findable.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/goldilock_provisioning_test.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_source_build_hfc_prefix.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_BUILD_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,6 +106,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_prepatch_resolver.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/fetchContentArgs_GIT_SHALLOW_test.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_BUILD_TARGETS.cpp
+++ b/test/check_BUILD_TARGETS.cpp
@@ -1,0 +1,35 @@
+#define BOOST_TEST_MODULE check_BUILD_TARGETS
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+ 
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+
+  BOOST_DATA_TEST_CASE(check_CUSTOM_INSTALL_TARGETS_works, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_BUILD_TARGETS", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "another-component"));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "some-component"));
+
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "yet-another-component"));
+  
+  }
+
+}

--- a/test/fetchContentArgs_GIT_SHALLOW_test.cpp
+++ b/test/fetchContentArgs_GIT_SHALLOW_test.cpp
@@ -1,0 +1,80 @@
+#define BOOST_TEST_MODULE fetchContentArgs_GIT_SHALLOW_test
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+
+ 
+namespace hfc::test { 
+namespace fs = boost::filesystem;
+namespace bp = boost::process;
+
+  struct td_struct_check_GIT_SHALLOW_args {
+    bool success_expected;
+    std::string cmake_flags;
+  };
+
+  static std::vector<td_struct_check_GIT_SHALLOW_args> TEST_DATA_clone_shallow = {
+    { true, "-DHFCTEST_DATA_GIT_SHALLOW_VALUE=ON" },
+    { false, "-DHFCTEST_DATA_GIT_SHALLOW_VALUE=OFF" },
+    { false, "" },  // off by default...
+  };
+
+  // make it printable for boost test  
+  static inline std::ostream& operator<<(std::ostream& os, const td_struct_check_GIT_SHALLOW_args& tc_data) {
+    os << "test data set: success_expected='" << std::to_string(tc_data.success_expected) << "', cmake_flags='" << tc_data.cmake_flags << "'";
+    return os;
+  }
+
+
+  BOOST_DATA_TEST_CASE(check_cmakelists_in_subfolder, 
+    boost::unit_test::data::make(test_variants()) * boost::unit_test::data::make(TEST_DATA_clone_shallow),
+    td_test_variant,
+    td_clone_shallow
+  ) {
+
+    fs::path project_path = prepare_project_to_be_tested("fetchContentArgs_GIT_SHALLOW", td_test_variant.is_cmake_re);
+    write_project_tipi_id(project_path);
+
+    std::string cmake_configure_command = get_cmake_configure_command(project_path, td_test_variant, td_clone_shallow.cmake_flags);
+
+    bool configure_success = false;
+
+    try {
+      run_command(cmake_configure_command, project_path); // the clone will be done after the configure command, no need to build for this one
+      configure_success = true;
+    }
+    catch(...) {
+      configure_success = false;
+    }
+
+    BOOST_REQUIRE(configure_success);
+
+    // the project write a dependency_sourcedir.txt in the sources root, read that
+    auto dependency_source_result_file = project_path / "build" / "dependency_sourcedir.txt";
+    BOOST_REQUIRE(fs::exists(dependency_source_result_file));
+
+    fs::path cloned_sources_path = pre::file::to_string(dependency_source_result_file.generic_string());
+    BOOST_REQUIRE(fs::exists(cloned_sources_path));
+
+    // check if the repo is a shallow clone 
+    auto git_bin = bp::search_path("git");
+    std::string check_is_shallow_cmd = git_bin.generic_string() + " rev-parse --is-shallow-repository"s;
+
+    auto gitcmd_result = run_cmd(bp::start_dir=cloned_sources_path, bp::shell, check_is_shallow_cmd);
+
+    // validate agains expected outcome
+    bool is_shallow = (gitcmd_result.output == "true");
+    BOOST_TEST_MESSAGE(gitcmd_result.output);
+    BOOST_REQUIRE(is_shallow == td_clone_shallow.success_expected);
+  }
+}

--- a/test/test_project_templates/check_BUILD_TARGETS/CMakeLists.txt
+++ b/test/test_project_templates/check_BUILD_TARGETS/CMakeLists.txt
@@ -1,0 +1,56 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  check_BUILD_TARGETS
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  components
+  GIT_REPOSITORY https://github.com/tipi-build/unit-test-cmake-install-components.git
+  GIT_TAG        bbe53f7fcf2824933bd2ef25dfb801b68723cd3a
+)
+
+FetchContent_MakeHermetic(
+  components 
+  
+  BUILD_TARGETS "some-component;another-component"
+  
+  HERMETIC_CMAKE_EXPORT_LIBRARY_DECLARATION  [=[
+    add_executable(some-component IMPORTED )
+    set_target_properties(some-component PROPERTIES 
+      IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/bin/some-component")
+    add_executable(another-component IMPORTED )
+    set_target_properties(another-component PROPERTIES 
+      IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/bin/another-component")
+  ]=]  
+
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime(components)
+
+get_target_property(some_component_LOCATION some-component IMPORTED_LOCATION)
+get_target_property(another_component_LOCATION another-component IMPORTED_LOCATION)
+
+cmake_path(GET some_component_LOCATION PARENT_PATH components_install_bin_folder)
+
+if(NOT EXISTS "${some_component_LOCATION}")
+  message(FATAL_ERROR "HFC didn't install requested components in BUILD_TARGETS: ${some_component_LOCATION}!")
+endif()
+
+if(NOT EXISTS "${another_component_LOCATION}")
+  message(FATAL_ERROR "HFC didn't install requested components in BUILD_TARGETS: ${another_component_LOCATION}!")
+endif()
+
+if(EXISTS "${components_install_bin_folder}/yet-another-component")
+  message(FATAL_ERROR "HFC installed all components but BUILD_TARGETS was provided !")
+endif()

--- a/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/CMakeLists.txt
+++ b/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/CMakeLists.txt
@@ -1,0 +1,50 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+set(git_shallow_arg_value "")
+if(HFCTEST_DATA_GIT_SHALLOW_VALUE) 
+  set(git_shallow_arg_value "GIT_SHALLOW" "${HFCTEST_DATA_GIT_SHALLOW_VALUE}")
+endif()
+
+
+FetchContent_Declare(
+  dependency
+  GIT_REPOSITORY https://github.com/tipi-build/unit-test-cmake-template-2libs.git
+  GIT_TAG 9652ce2756ae45f7124ba250ce9d98b7192b6102
+  SOURCE_SUBDIR build/cmake
+  ${git_shallow_arg_value} # may be empty, may be GIT_SHALLOW ON or GIT_SHALLOW OFF depending on $HFCTEST_DATA_GIT_SHALLOW_VALUE
+)
+
+FetchContent_MakeHermetic(
+  dependency
+  HERMETIC_BUILD_SYSTEM cmake
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime(dependency)
+
+
+FetchContent_GetProperties(dependency 
+  POPULATED result_dependency_POPULATED 
+  SOURCE_DIR result_dependency_SOURCE_DIR
+)
+
+
+message(STATUS "=======================")
+message(STATUS "POPULATED=${result_dependency_POPULATED}")
+message(STATUS "SOURCE_DIR=${result_dependency_SOURCE_DIR}")
+message(STATUS "=======================")
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/dependency_sourcedir.txt" "${result_dependency_SOURCE_DIR}")

--- a/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/simple_example.cpp
+++ b/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/simple_example.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Enable usage of GIT_SHALLOW in Hermetic FetchContent

CHANGELOG

- enable the usage of GIT_SHALLOW to do shallow clones of git dependencies in HFC

Change-Id: I08e696ad49118bcb31070ee304ffd0b364ad8eef