### PR TITLE
HermeticFetchContent v1.0.17

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
+++ b/.github/PULL_REQUEST_TEMPLATE/HFC-RELEASING.md
@@ -1,10 +1,9 @@
 ---
-name: [HFC] Release
-about: Checklist to make a release
+name: "[HFC] Release"
+about: "Checklist to make a release"
 title: "[HFC][RELEASE] v0.0."
-labels: ''
-assignees: ''
-
+labels: ""
+assignees: ""
 ---
 
 # How to make a release ?

--- a/cmake/modules/hfc_autotools_register_content_build.cmake
+++ b/cmake/modules/hfc_autotools_register_content_build.cmake
@@ -118,12 +118,19 @@ function(hfc_autotools_register_content_build content_name)
 
   endif()
   
-  if(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL)
+
+  if(HFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL)
     string(APPEND install_command " && ${CMAKE_COMMAND} -E rm -rf ${FN_ARG_PROJECT_BINARY_DIR} ")
   endif()
   
-  if(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL)
+  if(HFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL)
     string(APPEND install_command " && ${CMAKE_COMMAND} -E rm -rf ${FN_ARG_PROJECT_SOURCE_DIR} ")
+
+    hfc_compute_subbuild_path(${content_name} subbuild_path
+      SOURCE_DIR "${FN_ARG_PROJECT_SOURCE_DIR}"
+    )
+
+    string(APPEND install_command " && ${CMAKE_COMMAND} -E rm -rf ${subbuild_path} ")
   endif()
 
   #hfc_get_command_string_in_cleared_env("${build_command}" build_command)

--- a/cmake/modules/hfc_cmake_register_content_build.cmake
+++ b/cmake/modules/hfc_cmake_register_content_build.cmake
@@ -142,11 +142,17 @@ function(hfc_cmake_register_content_build content_name)
 
   endif()
 
-  if(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL)
+  if(HFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL)
     string(APPEND install_command " && ${CMAKE_COMMAND} -E rm -rf ${FN_ARG_PROJECT_BINARY_DIR} ")
   endif()
-  if(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL)
+  if(HFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL)
     string(APPEND install_command " && ${CMAKE_COMMAND} -E rm -rf ${FN_ARG_PROJECT_SOURCE_DIR} ")
+
+    hfc_compute_subbuild_path(${content_name} subbuild_path
+      SOURCE_DIR "${FN_ARG_PROJECT_SOURCE_DIR}"
+    )
+
+    string(APPEND install_command " && ${CMAKE_COMMAND} -E rm -rf ${subbuild_path} ")
   endif()
 
   if(DEFINED FN_ARG_PROJECT_SOURCE_SUBDIR)

--- a/cmake/modules/hfc_cmake_register_content_build.cmake
+++ b/cmake/modules/hfc_cmake_register_content_build.cmake
@@ -100,7 +100,7 @@ function(hfc_cmake_register_content_build content_name)
 
   endif()
 
-  if ("${FN_ARG_CUSTOM_INSTALL_TARGETS}" STREQUAL "")
+  if (NOT FN_ARG_BUILD_TARGETS AND (NOT FN_ARG_CUSTOM_INSTALL_TARGETS))
     list(APPEND install_commands_list "${CMAKE_COMMAND} --install .")
   endif()
 

--- a/cmake/modules/hfc_initialize.cmake
+++ b/cmake/modules/hfc_initialize.cmake
@@ -307,8 +307,8 @@ function(hfc_initialize HFC_ROOT_DIR)
     
     # Note : We don't set the following defaults on purpose as unset it will be evaluated OFF
     #        This allows also overriding with a pure scope variable and not CACHE
-    # set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing build")
-    # set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing sources after install")
+    # set(HFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing build")
+    # set(HFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE BOOL "By default save space by removing sources after install")
 
     set_property(GLOBAL PROPERTY HERMETIC_FETCHCONTENT_INITIALIZED ON)
     set(HERMETIC_FETCHCONTENT_ROOT_DIR "${HFC_ROOT_DIR}" CACHE INTERNAL "Root directory of Hermetic_FetchContent")

--- a/cmake/modules/hfc_make_available_single.cmake
+++ b/cmake/modules/hfc_make_available_single.cmake
@@ -68,6 +68,11 @@ function(hfc_make_available_single content_name build_at_configure_time)
     HERMETIC_DISCOVER_TARGETS_FILE_PATTERN
     
     HERMETIC_BUILD_AT_CONFIGURE_TIME
+
+    # Disambiguate parameter parsing with all supported
+    # fetchcontent-details
+    SBOM_LICENSE
+    SBOM_SUPPLIER
   )
 
   set(multi_value_params

--- a/cmake/modules/hfc_populate_project.cmake
+++ b/cmake/modules/hfc_populate_project.cmake
@@ -98,6 +98,7 @@ function(hfc_populate_project_declare content_name)
       GIT_REPOSITORY 
       GIT_TAG
       GIT_SUBMODULES
+      GIT_SHALLOW
       SOURCE_DIR 
       BUILD_IN_SOURCE_TREE
       SOURCE_SUBDIR
@@ -261,6 +262,10 @@ function(hfc_populate_project_declare content_name)
     elseif(FN_ARG_PATCH_COMMAND)
       list(APPEND populate_args "PATCH_COMMAND" "${FN_ARG_PATCH_COMMAND}")
       list(APPEND populate_args "UPDATE_DISCONNECTED" "1")  # avoid issues with repeated builds, which would "repatch"
+    endif()
+
+    if(FN_ARG_GIT_SHALLOW) 
+      list(APPEND populate_args "GIT_SHALLOW" ${FN_ARG_GIT_SHALLOW})
     endif()
     
     # we used to fix issues that could occur if the sources are missing but the stamp file were still around

--- a/cmake/modules/hfc_sbom.cmake
+++ b/cmake/modules/hfc_sbom.cmake
@@ -189,9 +189,9 @@ cmake_policy(SET CMP0007 NEW)
 function(file)
     list(GET ARGN 0 file_OP)
     list(GET ARGN 1 param_2)
-    list(SUBLIST ARGN 2 -1 remaining_args)
 
     if((\"\${file_OP}\" STREQUAL \"APPEND\") AND (\"\${param_2}\" STREQUAL \"\${spdx_in_file_dest}\"))
+        list(SUBLIST ARGN 2 -1 remaining_args)
         _file(APPEND \"\${spdx_in_file_tmp}\" \${remaining_args})
     elseif(\"\${file_OP}\" STREQUAL \"READ\") 
         _file(\${ARGN})
@@ -220,7 +220,10 @@ message(STATUS \" - generating SBOM\")
 
 set(SBOM_VERIFICATION_CODE \"\")
 configure_file(\"\${spdx_in_file_tmp}\" \"${output_destination_path}.\${tmp_suffix}\")
-file(COPY_FILE \"${output_destination_path}.\${tmp_suffix}\" \"${output_destination_path}\" ONLY_IF_DIFFERENT)
+file(TOUCH \"${output_destination_path}.lock\")
+file(LOCK \"${output_destination_path}.lock\")
+  file(COPY_FILE \"${output_destination_path}.\${tmp_suffix}\" \"${output_destination_path}\" ONLY_IF_DIFFERENT)
+file(LOCK \"${output_destination_path}.lock\" RELEASE)
 
 # clean up temp files
 message(STATUS \"Cleaning up temp files\")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/hermetic_dependency_make_executable_findable.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/goldilock_provisioning_test.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_source_build_hfc_prefix.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_BUILD_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_CUSTOM_INSTALL_TARGETS.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -106,6 +106,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/check_change_FETCHCONTENT_BASE_DIR.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_prepatch_resolver.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/fetchContentArgs_GIT_SHALLOW_test.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_BUILD_TARGETS.cpp
+++ b/test/check_BUILD_TARGETS.cpp
@@ -1,0 +1,35 @@
+#define BOOST_TEST_MODULE check_BUILD_TARGETS
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+ 
+namespace hfc::test { 
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+
+  BOOST_DATA_TEST_CASE(check_CUSTOM_INSTALL_TARGETS_works, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    fs::path test_project_path = prepare_project_to_be_tested("check_BUILD_TARGETS", data.is_cmake_re);
+    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    run_command(cmake_configure_command, test_project_path);
+    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
+    run_command(cmake_build_command, test_project_path);
+
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "another-component"));
+    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "some-component"));
+
+    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "components-install" / "bin" / "yet-another-component"));
+  
+  }
+
+}

--- a/test/check_delete_build_folder.cpp
+++ b/test/check_delete_build_folder.cpp
@@ -17,66 +17,115 @@ namespace hfc::test {
   namespace fs = boost::filesystem;
   namespace bp = boost::process;
 
-  BOOST_DATA_TEST_CASE(check_if_we_can_remove_build_and_source_folder, boost::unit_test::data::make(hfc::test::test_variants()), data){
-    fs::path test_project_path = prepare_project_to_be_tested("check_install-reuse", data.is_cmake_re);
-    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
-    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h"});
-    write_simple_main(test_project_path,{}, "simple_main.cpp");
+  struct td_struct_POST_BUILD_DATA_DELETION {
+    std::string cmake_flags = "";
+    bool expect_post_build_mathlib_BINARY_DIR_exists = true;
+    bool expect_post_build_mathlib_SOURCE_DIR_exists = true;
+  };
 
-    auto content = pre::file::to_string(project_toolchain.generic_string());
-    content += "\n  set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL ON CACHE BOOL \"\") \n set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL ON CACHE BOOL \"\")\n";
-    pre::file::from_string(project_toolchain.generic_string(), content);
-    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
-    run_command(cmake_configure_command, test_project_path);
-    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
-    run_command(cmake_build_command, test_project_path);
+  static std::vector<td_struct_POST_BUILD_DATA_DELETION> TEST_DATA_hfc_delete_post_build = {
+    /* remove BINARY_DIR and SOURCE_DIR  */
+    { "-DHFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL=ON -DHFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL=ON", false, false  },
+    
+    /* remove only BINARY_DIR */ 
+    { "-DHFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL=ON -DHFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL=OFF", false, true },
+    { "-DHFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL=ON", false, true },
 
-    BOOST_REQUIRE(!fs::exists(test_project_path / "build" / "_deps" / "project-cmake-simple-build" / "CMakeCache.txt"));
-    if(!data.is_cmake_re){
-      BOOST_REQUIRE(!fs::exists(test_project_path / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt"));
-    }else if(data.is_cmake_re){
-      BOOST_REQUIRE(!fs::exists(get_mirror_test_project_path(test_project_path) / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt" ));
-    } 
+    /* remove only SOURCE_DIR */ 
+    { "-DHFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL=OFF -DHFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL=ON", true, false},
+    { "-DHFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL=ON", true, false },
+
+    /* remove none (default too) */
+    { "-DHFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL=OFF -DHFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL=OFF", true, true },
+    { "", true, true }
+  };
+
+
+  static auto TEST_DATA_make_mathlib_available_at = {
+    "buildtime",
+    "configuretime"
+  };
+
+  
+  // make it printable for boost test  
+  static inline std::ostream& operator<<(std::ostream& os, const td_struct_POST_BUILD_DATA_DELETION& tc_data) {
+    os <<  "td_struct_POST_BUILD_DATA_DELETION: cmake_flags='" << tc_data.cmake_flags 
+        << "', expect_post_build_mathlib_BINARY_DIR_exists=" << std::to_string(tc_data.expect_post_build_mathlib_BINARY_DIR_exists)
+        << ", expect_post_build_mathlib_SOURCE_DIR_exists=" << std::to_string(tc_data.expect_post_build_mathlib_SOURCE_DIR_exists);
+    return os;
   }
 
-  BOOST_DATA_TEST_CASE(check_if_we_can_keep_build_and_source_folder, boost::unit_test::data::make(hfc::test::test_variants()), data){
-    fs::path test_project_path = prepare_project_to_be_tested("check_install-reuse", data.is_cmake_re);
-    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
-    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h"});
-    write_simple_main(test_project_path,{}, "simple_main.cpp");
 
-    auto content = pre::file::to_string(project_toolchain.generic_string());
-    content += "\n  set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE BOOL \"\") \n set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE BOOL \"\")\n";
-    pre::file::from_string(project_toolchain.generic_string(), content);
-    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
-    run_command(cmake_configure_command, test_project_path);
-    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
-    run_command(cmake_build_command, test_project_path);
+  BOOST_DATA_TEST_CASE(test_post_build_removal_feature, 
+    boost::unit_test::data::make(hfc::test::test_variants()) * boost::unit_test::data::make(TEST_DATA_hfc_delete_post_build) * boost::unit_test::data::make(TEST_DATA_make_mathlib_available_at),
+    td_test_variant,
+    td_test_case,
+    td_make_mathlib_available_at
+  ) {
 
-    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "project-cmake-simple-build" / "CMakeCache.txt"));
-    if(!data.is_cmake_re){
-      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt"));
-    }else if(data.is_cmake_re){
-      BOOST_REQUIRE(fs::exists(get_mirror_test_project_path(test_project_path) / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt" ));
-    } 
+    fs::path project_path = prepare_project_to_be_tested("check_delete_sources_after_build", td_test_variant.is_cmake_re);
+    write_project_tipi_id(project_path);
+
+    // that's the same every time
+    std::string cmake_build_command = get_cmake_build_command(project_path, td_test_variant);
+  
+
+
+    auto get_cmakeflags = [&](std::string injected_data) {
+      return td_test_case.cmake_flags + " -DTEST_DATA_INJECTED="s + injected_data + " -DTEST_DATA_MAKE_AVAILABLE_AT="s + td_make_mathlib_available_at;
+    };
+
+    {
+      std::string first_run_cmakeflags = get_cmakeflags("first");
+      std::string first_configure_cmd = get_cmake_configure_command(project_path, td_test_variant, first_run_cmakeflags);
+      bool first_configure_success = false;
+
+      try {
+        run_command(first_configure_cmd, project_path); // the clone will be done after the configure command, no need to build for this one
+        first_configure_success = true;
+      }
+      catch(...) {
+        first_configure_success = false;
+      }
+
+      BOOST_REQUIRE(first_configure_success);
+      run_command(cmake_build_command, project_path);
+    }
+
+    fs::path expected_mathlib_binary_dir = project_path / "build" / "_deps" / "mathlib-build" / "CMakeCache.txt";
+    fs::path expected_mathlib_source_dir = (td_test_variant.is_cmake_re) 
+      ? get_mirror_test_project_path(project_path) / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "CMakeLists.txt"
+      : project_path / "thirdparty" / "cache" / "mathlib-ecc756a4-src" / "CMakeLists.txt"
+    ;
+
+    BOOST_REQUIRE(fs::exists(expected_mathlib_source_dir) == td_test_case.expect_post_build_mathlib_SOURCE_DIR_exists);
+    BOOST_REQUIRE(fs::exists(expected_mathlib_binary_dir) == td_test_case.expect_post_build_mathlib_BINARY_DIR_exists);
+
+    // now reconfigure injecting the "second run testdata"
+    // dependending on the input settings hfc will have to fetch the
+    // dependency again to do a build
+    // this way this test ensures that no matter the parameter combination
+    // of HFC_V1_REMOVE_BUILD_DIR_AFTER_INSTALL // HFC_V1_REMOVE_SOURCE_DIR_AFTER_INSTALL
+    // we wiil still manage to get the correct outcome
+    {
+      std::string second_run_cmakeflags = get_cmakeflags("second");
+      std::string second_configure_cmd = get_cmake_configure_command(project_path, td_test_variant, second_run_cmakeflags);
+      bool second_configure_success = false;
+
+      try {
+        run_command(second_configure_cmd, project_path); // the clone will be done after the configure command, no need to build for this one
+        second_configure_success = true;
+      }
+      catch(...) {
+        second_configure_success = false;
+      }
+
+      BOOST_REQUIRE(second_configure_success);
+      run_command(cmake_build_command, project_path);
+    }
+
+    BOOST_REQUIRE(fs::exists(expected_mathlib_source_dir) == td_test_case.expect_post_build_mathlib_SOURCE_DIR_exists);
+    BOOST_REQUIRE(fs::exists(expected_mathlib_binary_dir) == td_test_case.expect_post_build_mathlib_BINARY_DIR_exists);
   }
 
-  BOOST_DATA_TEST_CASE(check_if_we_can_keep_build_and_source_folder_without_define_value, boost::unit_test::data::make(hfc::test::test_variants()), data){
-    fs::path test_project_path = prepare_project_to_be_tested("check_install-reuse", data.is_cmake_re);
-    fs::path project_toolchain = get_project_toolchain_path(test_project_path);
-    write_simple_main(test_project_path,{"MathFunctions.h", "MathFunctionscbrt.h"});
-    write_simple_main(test_project_path,{}, "simple_main.cpp");
-
-    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
-    run_command(cmake_configure_command, test_project_path);
-    std::string cmake_build_command = get_cmake_build_command(test_project_path, data);
-    run_command(cmake_build_command, test_project_path);
-
-    BOOST_REQUIRE(fs::exists(test_project_path / "build" / "_deps" / "project-cmake-simple-build" / "CMakeCache.txt"));
-    if(!data.is_cmake_re){
-      BOOST_REQUIRE(fs::exists(test_project_path / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt"));
-    }else if(data.is_cmake_re){
-      BOOST_REQUIRE(fs::exists(get_mirror_test_project_path(test_project_path) / "thirdparty" / "cache" / "project-cmake-simple-ecc756a4-src" / "CMakeLists.txt" ));
-    } 
-  }
 }

--- a/test/fetchContentArgs_GIT_SHALLOW_test.cpp
+++ b/test/fetchContentArgs_GIT_SHALLOW_test.cpp
@@ -1,0 +1,80 @@
+#define BOOST_TEST_MODULE fetchContentArgs_GIT_SHALLOW_test
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+
+ 
+namespace hfc::test { 
+namespace fs = boost::filesystem;
+namespace bp = boost::process;
+
+  struct td_struct_check_GIT_SHALLOW_args {
+    bool success_expected;
+    std::string cmake_flags;
+  };
+
+  static std::vector<td_struct_check_GIT_SHALLOW_args> TEST_DATA_clone_shallow = {
+    { true, "-DHFCTEST_DATA_GIT_SHALLOW_VALUE=ON" },
+    { false, "-DHFCTEST_DATA_GIT_SHALLOW_VALUE=OFF" },
+    { false, "" },  // off by default...
+  };
+
+  // make it printable for boost test  
+  static inline std::ostream& operator<<(std::ostream& os, const td_struct_check_GIT_SHALLOW_args& tc_data) {
+    os << "test data set: success_expected='" << std::to_string(tc_data.success_expected) << "', cmake_flags='" << tc_data.cmake_flags << "'";
+    return os;
+  }
+
+
+  BOOST_DATA_TEST_CASE(check_cmakelists_in_subfolder, 
+    boost::unit_test::data::make(test_variants()) * boost::unit_test::data::make(TEST_DATA_clone_shallow),
+    td_test_variant,
+    td_clone_shallow
+  ) {
+
+    fs::path project_path = prepare_project_to_be_tested("fetchContentArgs_GIT_SHALLOW", td_test_variant.is_cmake_re);
+    write_project_tipi_id(project_path);
+
+    std::string cmake_configure_command = get_cmake_configure_command(project_path, td_test_variant, td_clone_shallow.cmake_flags);
+
+    bool configure_success = false;
+
+    try {
+      run_command(cmake_configure_command, project_path); // the clone will be done after the configure command, no need to build for this one
+      configure_success = true;
+    }
+    catch(...) {
+      configure_success = false;
+    }
+
+    BOOST_REQUIRE(configure_success);
+
+    // the project write a dependency_sourcedir.txt in the sources root, read that
+    auto dependency_source_result_file = project_path / "build" / "dependency_sourcedir.txt";
+    BOOST_REQUIRE(fs::exists(dependency_source_result_file));
+
+    fs::path cloned_sources_path = pre::file::to_string(dependency_source_result_file.generic_string());
+    BOOST_REQUIRE(fs::exists(cloned_sources_path));
+
+    // check if the repo is a shallow clone 
+    auto git_bin = bp::search_path("git");
+    std::string check_is_shallow_cmd = git_bin.generic_string() + " rev-parse --is-shallow-repository"s;
+
+    auto gitcmd_result = run_cmd(bp::start_dir=cloned_sources_path, bp::shell, check_is_shallow_cmd);
+
+    // validate agains expected outcome
+    bool is_shallow = (gitcmd_result.output == "true");
+    BOOST_TEST_MESSAGE(gitcmd_result.output);
+    BOOST_REQUIRE(is_shallow == td_clone_shallow.success_expected);
+  }
+}

--- a/test/test_project_templates/check_BUILD_TARGETS/CMakeLists.txt
+++ b/test/test_project_templates/check_BUILD_TARGETS/CMakeLists.txt
@@ -1,0 +1,56 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  check_BUILD_TARGETS
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  components
+  GIT_REPOSITORY https://github.com/tipi-build/unit-test-cmake-install-components.git
+  GIT_TAG        bbe53f7fcf2824933bd2ef25dfb801b68723cd3a
+)
+
+FetchContent_MakeHermetic(
+  components 
+  
+  BUILD_TARGETS "some-component;another-component"
+  
+  HERMETIC_CMAKE_EXPORT_LIBRARY_DECLARATION  [=[
+    add_executable(some-component IMPORTED )
+    set_target_properties(some-component PROPERTIES 
+      IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/bin/some-component")
+    add_executable(another-component IMPORTED )
+    set_target_properties(another-component PROPERTIES 
+      IMPORTED_LOCATION "@HFC_PREFIX_PLACEHOLDER@/bin/another-component")
+  ]=]  
+
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime(components)
+
+get_target_property(some_component_LOCATION some-component IMPORTED_LOCATION)
+get_target_property(another_component_LOCATION another-component IMPORTED_LOCATION)
+
+cmake_path(GET some_component_LOCATION PARENT_PATH components_install_bin_folder)
+
+if(NOT EXISTS "${some_component_LOCATION}")
+  message(FATAL_ERROR "HFC didn't install requested components in BUILD_TARGETS: ${some_component_LOCATION}!")
+endif()
+
+if(NOT EXISTS "${another_component_LOCATION}")
+  message(FATAL_ERROR "HFC didn't install requested components in BUILD_TARGETS: ${another_component_LOCATION}!")
+endif()
+
+if(EXISTS "${components_install_bin_folder}/yet-another-component")
+  message(FATAL_ERROR "HFC installed all components but BUILD_TARGETS was provided !")
+endif()

--- a/test/test_project_templates/check_CUSTOM_INSTALL_TARGETS/CMakeLists.txt
+++ b/test/test_project_templates/check_CUSTOM_INSTALL_TARGETS/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 FetchContent_Declare(

--- a/test/test_project_templates/check_compiler_forwarding/CMakeLists.txt
+++ b/test/test_project_templates/check_compiler_forwarding/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 FetchContent_Declare(

--- a/test/test_project_templates/check_compiler_forwarding_autotools/CMakeLists.txt
+++ b/test/test_project_templates/check_compiler_forwarding_autotools/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 

--- a/test/test_project_templates/check_delete_sources_after_build/CMakeLists.txt
+++ b/test/test_project_templates/check_delete_sources_after_build/CMakeLists.txt
@@ -1,0 +1,67 @@
+
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(FetchContent)
+include(HermeticFetchContent)
+
+FetchContent_Declare(
+  mathlib
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92"
+)
+
+
+string(CONFIGURE 
+  [=[
+  set(test_data_injected "@TEST_DATA_INJECTED@")
+  if(test_data_injected STREQUAL "")
+    message(FATAL_ERROR "No value set for test_data_injected / TEST_DATA_INJECTED")
+  endif()
+  ]=]
+  toolchain_ext
+  @ONLY
+)
+
+
+FetchContent_MakeHermetic(
+  mathlib
+  HERMETIC_TOOLCHAIN_EXTENSION "${toolchain_ext}"
+)
+
+if(TEST_DATA_MAKE_AVAILABLE_AT STREQUAL "configuretime")
+  HermeticFetchContent_MakeAvailableAtConfigureTime(mathlib)
+elseif(TEST_DATA_MAKE_AVAILABLE_AT STREQUAL "buildtime")
+  HermeticFetchContent_MakeAvailableAtBuildTime(mathlib)
+else()
+  message(FATAL_ERROR "Wrong value of TEST_DATA_MAKE_AVAILABLE_AT")
+endif()
+
+FetchContent_GetProperties(mathlib 
+  POPULATED result_mathlib_POPULATED 
+  SOURCE_DIR result_mathlib_SOURCE_DIR
+  BINARY_DIR result_mathlib_BINARY_DIR
+)
+
+message(STATUS "=======================")
+message(STATUS "mathlib properties:")
+message(STATUS "POPULATED=${result_mathlib_POPULATED}")
+message(STATUS "SOURCE_DIR=${result_mathlib_SOURCE_DIR}")
+message(STATUS "BINARY_DIR=${result_mathlib_BINARY_DIR}")
+message(STATUS "=======================")
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mathlib_sourcedir.txt" "${result_dependency_SOURCE_DIR}")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/mathlib_binarydir.txt" "${result_mathlib_BINARY_DIR}")
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::MathFunctions MathFunctionscbrt::MathFunctionscbrt)

--- a/test/test_project_templates/check_delete_sources_after_build/simple_example.cpp
+++ b/test/test_project_templates/check_delete_sources_after_build/simple_example.cpp
@@ -1,0 +1,5 @@
+#include <MathFunctions.h>
+
+int main() {
+    return MathFunctions::sqrt(4.0) == 2.0;
+}

--- a/test/test_project_templates/check_options_and_defines_forwarding/CMakeLists.txt
+++ b/test/test_project_templates/check_options_and_defines_forwarding/CMakeLists.txt
@@ -10,8 +10,6 @@ set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
   ${CMAKE_MODULE_PATH}
 )
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 

--- a/test/test_project_templates/check_options_and_defines_forwarding_autotools/CMakeLists.txt
+++ b/test/test_project_templates/check_options_and_defines_forwarding_autotools/CMakeLists.txt
@@ -11,8 +11,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 

--- a/test/test_project_templates/check_prepatch_resolver/CMakeLists.txt
+++ b/test/test_project_templates/check_prepatch_resolver/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 FetchContent_Declare(

--- a/test/test_project_templates/check_source_build_hfc_prefix/CMakeLists.txt
+++ b/test/test_project_templates/check_source_build_hfc_prefix/CMakeLists.txt
@@ -12,8 +12,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 FetchContent_Declare(

--- a/test/test_project_templates/configure_stability_autotools_dependency_AtConfigureTime/CMakeLists.txt
+++ b/test/test_project_templates/configure_stability_autotools_dependency_AtConfigureTime/CMakeLists.txt
@@ -11,8 +11,6 @@ set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
   ${CMAKE_MODULE_PATH}
 )
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 FetchContent_Declare(

--- a/test/test_project_templates/configure_stability_cmake_dependency_AtBuildTime/CMakeLists.txt
+++ b/test/test_project_templates/configure_stability_cmake_dependency_AtBuildTime/CMakeLists.txt
@@ -11,8 +11,6 @@ set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
   ${CMAKE_MODULE_PATH}
 )
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 

--- a/test/test_project_templates/configure_stability_cmake_dependency_AtConfigureTime/CMakeLists.txt
+++ b/test/test_project_templates/configure_stability_cmake_dependency_AtConfigureTime/CMakeLists.txt
@@ -11,8 +11,6 @@ set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
   ${CMAKE_MODULE_PATH}
 )
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 

--- a/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/CMakeLists.txt
+++ b/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/CMakeLists.txt
@@ -1,0 +1,50 @@
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+set(git_shallow_arg_value "")
+if(HFCTEST_DATA_GIT_SHALLOW_VALUE) 
+  set(git_shallow_arg_value "GIT_SHALLOW" "${HFCTEST_DATA_GIT_SHALLOW_VALUE}")
+endif()
+
+
+FetchContent_Declare(
+  dependency
+  GIT_REPOSITORY https://github.com/tipi-build/unit-test-cmake-template-2libs.git
+  GIT_TAG 9652ce2756ae45f7124ba250ce9d98b7192b6102
+  SOURCE_SUBDIR build/cmake
+  ${git_shallow_arg_value} # may be empty, may be GIT_SHALLOW ON or GIT_SHALLOW OFF depending on $HFCTEST_DATA_GIT_SHALLOW_VALUE
+)
+
+FetchContent_MakeHermetic(
+  dependency
+  HERMETIC_BUILD_SYSTEM cmake
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime(dependency)
+
+
+FetchContent_GetProperties(dependency 
+  POPULATED result_dependency_POPULATED 
+  SOURCE_DIR result_dependency_SOURCE_DIR
+)
+
+
+message(STATUS "=======================")
+message(STATUS "POPULATED=${result_dependency_POPULATED}")
+message(STATUS "SOURCE_DIR=${result_dependency_SOURCE_DIR}")
+message(STATUS "=======================")
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/dependency_sourcedir.txt" "${result_dependency_SOURCE_DIR}")

--- a/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/simple_example.cpp
+++ b/test/test_project_templates/fetchContentArgs_GIT_SHALLOW/simple_example.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/test/test_project_templates/hfc-recursive-autotools/CMakeLists.txt
+++ b/test/test_project_templates/hfc-recursive-autotools/CMakeLists.txt
@@ -28,8 +28,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 FetchContent_Declare(

--- a/test/test_project_templates/hfc-recursive-cmake_autotools/CMakeLists.txt
+++ b/test/test_project_templates/hfc-recursive-cmake_autotools/CMakeLists.txt
@@ -27,8 +27,6 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
 )
 
-set(HERMETIC_FETCHCONTENT_REMOVE_BUILD_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the binary dirs to enable detection of cache entries")
-set(HERMETIC_FETCHCONTENT_REMOVE_SOURCE_DIR_AFTER_INSTALL OFF CACHE INTERNAL "Avoid deletion of the source dirs after install")
 include(HermeticFetchContent)
 
 FetchContent_Declare(


### PR DESCRIPTION
# Release Checklist
HFC is a source package in that regard we don't want to have a special workflow transforming the sources or have the sources be different when released than when edited and tested.

In that regard we will make every merged-commit releasable.

- [x] Check that every commit in the main branch should read as follow : 

```
HermeticFetchContent v1.0.X : <TITLE>
<OR> CONFIG : <TITLE>
<OR> DOC : <TITLE>
<OR> TEST : <TITLE>

<summary...>

CHANGELOG

- User Facing Change Description

Change-Id: <gerrit-compatible-change-id>
```

## Pre-Release
- [x] Create a `release/v1.0.X` integration branch
    - Each feature should be one commit following template above
    - Each feature should have CI status passing

## Release scope : Rebase into current PR
- [x] #18
- [x] BUILD_TARGETS fixes and test suite 
- [x] #21 
- [x] tipi-build/specs-cmake-re/issues/41
- [x] Fix SBOM parsing in hfc_make_available

## Full-Release
- [x] Test with Canary projects
  - [x] canary-big
    - [x] cmake (@pysco68   linux  debug ) 
    - [x] cmake (@daminetreg macos release ) https://tipibuild.slack.com/archives/C055MS3DG92/p1738972441222119
    - [x] cmake-re (@daminetreg gcc14) https://tipibuild.slack.com/archives/C055MS3DG92/p1738965755149439
  - [x] canary-medium https://tipibuild.slack.com/archives/C055MS3DG92/p1738958322348439?thread_ts=1738955490.739249&cid=C055MS3DG92
      - [x] cmake (@Lambourl) 
      - [x] cmake-re (@Lambourl) 
- [ ] Take the `release/v1.0.17` and **fast-forward** it in main
    - [x] `git checkout main && git pull origin main --ff-only && git pull origin release/v1.0.17 --ff-only` 
    - [ ] Reset after pushing to main release/v1.0.17 to actual v1.0.17.