### PR TITLE
HermeticFetchContent v1.0.20 : Remove symlink target when cleaning existing build trees

### DIFF
--- a/cmake/modules/hfc_autotools_restore_or_configure.cmake
+++ b/cmake/modules/hfc_autotools_restore_or_configure.cmake
@@ -257,6 +257,17 @@ function(hfc_autotools_restore_or_configure content_name)
       # If not restored, prepare the build tree (autotools sources need to be downloaded in the CMake project build tree, as the autotools sources can only build in-source-tree.
       # The CMake project sources are in the autotools_cmake_adapter_destination
       hfc_autootols_prepare_mirror_build_tree_to_host_configure(${content_name} ${autotools_cmake_adapter_destination} ${FN_ARG_PROJECT_INSTALL_PREFIX} ${FN_ARG_PROJECT_SOURCE_DIR} ${proxy_toolchain_path} "${FN_ARG_ORIGIN}")
+      if(IS_SYMLINK "${FN_ARG_PROJECT_INSTALL_PREFIX}")
+        file(READ_SYMLINK  "${FN_ARG_PROJECT_INSTALL_PREFIX}" symlink_destination)
+        get_filename_component(symlink_parent_dir "${symlink_destination}" DIRECTORY)
+        set(symlink_bin_dir "${symlink_parent_dir}/bin")
+        file(REMOVE_RECURSE "${FN_ARG_PROJECT_BINARY_DIR}")
+        file(CREATE_LINK
+          "${symlink_bin_dir}"
+          "${FN_ARG_PROJECT_BINARY_DIR}"
+          SYMBOLIC
+        )
+      endif()
 
       if (NOT EXISTS "${FN_ARG_PROJECT_SOURCE_DIR}")
         # If we are here once again, it's because abi-hash changed for example: then the build tree is empty.

--- a/cmake/modules/hfc_run_project_configure.cmake
+++ b/cmake/modules/hfc_run_project_configure.cmake
@@ -61,6 +61,12 @@ function(hfc_run_project_configure content_name)
 
   # make sure to avoid issues that could occur when reconfiguring an existing tree
   if(EXISTS "${FN_ARG_PROJECT_BINARY_DIR}")
+    if(IS_SYMLINK "${FN_ARG_PROJECT_BINARY_DIR}")
+      file(READ_SYMLINK "${FN_ARG_PROJECT_BINARY_DIR}" symlink_destination)
+      if(EXISTS "${symlink_destination}")
+        file(REMOVE_RECURSE "${symlink_destination}")
+      endif()
+    endif()
     file(REMOVE_RECURSE "${FN_ARG_PROJECT_BINARY_DIR}")
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,6 +107,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/check_delete_build_folder.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_prepatch_resolver.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/fetchContentArgs_GIT_SHALLOW_test.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_version_update.cpp"
 )
 
 foreach(test_file IN LISTS test_source_files)

--- a/test/check_version_update.cpp
+++ b/test/check_version_update.cpp
@@ -1,0 +1,49 @@
+#define BOOST_TEST_MODULE check_update_version
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+
+#include <pre/file/string.hpp>
+
+
+namespace hfc::test {
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+  using namespace std::string_literals;
+
+  BOOST_DATA_TEST_CASE(check_version_update, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    std::string first_commit = "790f82e8a01b062b34133ef71dd94e9468717f37";
+    std::string second_commit = "5cfd9d4e490d910acef72782e058739a83837305";
+    fs::path test_project_path = prepare_project_to_be_tested("check_version_update", data.is_cmake_re);
+    write_simple_main(test_project_path, {"version.hpp"});
+    write_simple_main(test_project_path, {}, "simple_main.cpp" );
+
+    auto test_environment = boost::this_process::environment();
+    test_environment["TIPI_CACHE_FORCE_ENABLE"] = "OFF";
+    test_environment["TIPI_CACHE_CONSUME_ONLY"] = "ON";
+
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+    auto result = run_cmd(test_environment, bp::start_dir=(test_project_path), bp::shell, cmake_configure_command);
+    BOOST_REQUIRE(result.return_code == 0);
+
+    auto cmake_cache_path = test_project_path / "build" / "_deps" / "version_update-build" / "CMakeCache.txt";
+    auto content_cmake_cache = pre::file::to_string(cmake_cache_path.generic_string());
+    BOOST_REQUIRE(boost::contains(content_cmake_cache, "FAKECACHEDEP_MODE:STRING=v1"));
+
+    auto content = pre::file::to_string((test_project_path/ "CMakeLists.txt").generic_string());
+    boost::replace_all(content, first_commit, second_commit);
+    pre::file::from_string((test_project_path/ "CMakeLists.txt").generic_string(), content);
+
+    result = run_cmd(test_environment, bp::start_dir=(test_project_path), bp::shell, cmake_configure_command);
+    BOOST_REQUIRE(result.return_code == 0);
+    content_cmake_cache = pre::file::to_string(cmake_cache_path.generic_string());
+    BOOST_REQUIRE(boost::contains(content_cmake_cache, "FAKECACHEDEP_MODE:STRING=v2"));
+  }
+}

--- a/test/test_project_templates/check_version_update/CMakeLists.txt
+++ b/test/test_project_templates/check_version_update/CMakeLists.txt
@@ -1,0 +1,34 @@
+
+cmake_minimum_required(VERSION 3.27.6)
+project(
+  ModernCMakeExample
+  VERSION 1.0
+  LANGUAGES CXX)
+
+
+set(CMAKE_MODULE_PATH
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  ${CMAKE_MODULE_PATH}
+)
+
+include(HermeticFetchContent)
+
+
+FetchContent_Declare(
+  "version_update"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-version-update.git"
+  GIT_TAG "790f82e8a01b062b34133ef71dd94e9468717f37"
+)
+
+FetchContent_MakeHermetic(
+  "version_update"
+  HERMETIC_BUILD_SYSTEM cmake
+)
+
+HermeticFetchContent_MakeAvailableAtConfigureTime("version_update")
+
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE fakecachedep::fakecachedep)
+add_executable(MySimpleMain simple_main.cpp)
+


### PR DESCRIPTION
When reconfiguring an existing project binary directory, HFC previously removed only the symlink path itself. If the binary directory was a symlink, the real target directory could remain on disk and lead to stale build state.

This change resolves the real path of a symlinked project binary directory and removes the target directory before removing the symlink entry itself.

Also add check_version_update.cpp to the test suite.

CHANGELOG

- Fix cleanup of symlinked project build directories during reconfiguration to avoid stale build state.

Change-Id: Id104e8b8b70088f89dbd2c838f881a930198b41b