### PR TITLE
CONFIG: Update example environments and fix gRPC example configure

### DIFF
--- a/example/boost/environments/linux-tipi-ubuntu-cxx17.pkr.js
+++ b/example/boost/environments/linux-tipi-ubuntu-cxx17.pkr.js
@@ -3,17 +3,8 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu:{{tipi_cli_version}}",
-      "platform": "linux/amd64",
+      "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    {
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
-  ],
-  "_tipi_version": "{{tipi_version_hash}}"
+  ]
 }

--- a/example/grpc_use_3rd_party_cmake_modules/CMakeLists.txt
+++ b/example/grpc_use_3rd_party_cmake_modules/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(grpc-stubs OBJECT "proto/greeter.proto")
 target_link_libraries(grpc-stubs PUBLIC ${GRPC_STUB_LIBRARIES})
 
 set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
+file(MAKE_DIRECTORY "${PROTO_BINARY_DIR}")
 target_include_directories(grpc-stubs PUBLIC "$<BUILD_INTERFACE:${PROTO_BINARY_DIR}>")
 
 set(PROTO_IMPORT_DIRS "${CMAKE_CURRENT_LIST_DIR}/proto")

--- a/example/grpc_use_3rd_party_cmake_modules/README.md
+++ b/example/grpc_use_3rd_party_cmake_modules/README.md
@@ -11,7 +11,7 @@ This shows how to setup a complex dependency tree as well as make 3rd party pack
 You will not need any additional dependencies aside from cmake itself as protoc and all the required libraries are added during the build. To build the project you can run:
 
 ```sh
-cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../../toolchain/toolchain.cmake
 cmake --build build
 ```
 

--- a/example/openssl/environments/linux-tipi-ubuntu-cxx17.pkr.js
+++ b/example/openssl/environments/linux-tipi-ubuntu-cxx17.pkr.js
@@ -3,17 +3,8 @@
   "builders": [
     {
       "type": "docker",
-      "image": "tipibuild/tipi-ubuntu:{{tipi_cli_version}}",
-      "platform": "linux/amd64",
+      "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
       "commit": true
     }
-  ],
-  "post-processors": [
-    {
-      "type": "docker-tag",
-      "repository": "linux",
-      "tag": "latest"
-    }
-  ],
-  "_tipi_version": "{{tipi_version_hash}}"
+  ]
 }


### PR DESCRIPTION
Update example `.pkr.js` files to use `{{cmake_re_source_hash}}` and remove the deprecated part

Also fix the gRPC 3rd-party CMake modules example by creating the generated proto output directory before it is used, and update the README to document configuration with the HFC toolchain file.

Change-Id: I0f6298e11f5b9aabfc4be4feb2e35db775b4c5bb