### PR TITLE
TEST: Add CI workflow for examples and improve example reproducibility

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,0 +1,158 @@
+name: example build
+
+# This workflow is triggered on PRs ony
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+env:
+  TIPI_ACCESS_TOKEN: ${{ secrets.HFC_TIPI_TEST_USER_TIPI_ACCESS_TOKEN }}
+  TIPI_REFRESH_TOKEN: ${{ secrets.HFC_TIPI_TEST_USER_TIPI_REFRESH_TOKEN }}
+  TIPI_VAULT_PASSPHRASE: ${{ secrets.HFC_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}
+  TIPI_CACHE_CONSUME_ONLY: ON
+  COMMIT_ID: ${{ github.event.pull_request.head.sha }}
+
+
+jobs:
+  build-example-boost:
+    name: build example with boost
+    runs-on: ubuntu-latest-8-cores
+    container:
+      image: tipibuild/tipi-ubuntu:latest
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v4
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: prepare example runner
+        run: |
+          cd hfc_project/example/boost
+          git init
+          git config --global user.email "hello@tipi.build"
+          git config --global user.name "tipibuild"
+          tipi connect
+      - name: build with cmake-re
+        run: |
+          cd hfc_project/example/boost
+          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
+          cmake-re --build ./build_re --host
+      - name: build with cmake
+        run: |
+          cd hfc_project/example/boost
+          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
+          tipi run cmake --build ./build
+
+  build-example-get-started:
+    name: build example get-started
+    runs-on: ubuntu-latest-8-cores
+    container:
+      image: tipibuild/tipi-ubuntu:latest
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v4
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: prepare example runner
+        run: |
+          cd hfc_project/example/get-started
+          git init
+          git config --global user.email "hello@tipi.build"
+          git config --global user.name "tipibuild"
+          tipi connect
+      - name: build with cmake-re
+        run: |
+          cd hfc_project/example/get-started
+          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
+          cmake-re --build ./build_re --host
+      - name: build with cmake
+        run: |
+          cd hfc_project/example/get-started
+          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
+          tipi run cmake --build ./build
+
+# This example is split into separate cmake-re and cmake jobs because it is significantly slower than others (gRPC dependency tree). Splitting improves CI parallelism and reduces overall execution time.
+#  build-example-with-grpc-cmake-re:
+#    name: build example grpc_use_3rd_party_cmake_modules with cmake-re
+#    runs-on: ubuntu-latest-8-cores
+#    container:
+#      image: tipibuild/tipi-ubuntu:latest
+#      options: --user root
+#    steps:
+#      - name: checkout pull request
+#        uses: actions/checkout@v4
+#        with:
+#          path: './hfc_project'
+#          ref: ${{ github.event.pull_request.head.sha }}
+#      - name: prepare example runner
+#        run: |
+#          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
+#          git init
+#          git config --global user.email "hello@tipi.build"
+#          git config --global user.name "tipibuild"
+#          tipi connect
+#      - name: build with cmake-re
+#        run: |
+#          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
+#          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
+#          cmake-re --build ./build_re --host
+
+  build-example-with-grpc-cmake:
+    name: build example grpc_use_3rd_party_cmake_modules with cmake
+    runs-on: ubuntu-latest-8-cores
+    container:
+      image: tipibuild/tipi-ubuntu:latest
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v4
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: prepare example runner
+        run: |
+          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
+          git init
+          git config --global user.email "hello@tipi.build"
+          git config --global user.name "tipibuild"
+          tipi connect
+      - name: build with cmake
+        run: |
+          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
+          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
+          tipi run cmake --build ./build
+
+  build-example-with-openssl:
+    name: build example openssl
+    runs-on: ubuntu-latest-8-cores
+    container:
+      image: tipibuild/tipi-ubuntu:latest
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v4
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: prepare example runner
+        run: |
+          cd hfc_project/example/openssl
+          git init
+          git config --global user.email "hello@tipi.build"
+          git config --global user.name "tipibuild"
+          tipi connect
+      - name: build with cmake-re
+        run: |
+          cd hfc_project/example/openssl
+          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
+          cmake-re --build ./build_re --host
+      - name: build with cmake
+        run: |
+          cd hfc_project/example/openssl
+          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
+          tipi run cmake --build ./build

--- a/example/boost/CMakeLists.txt
+++ b/example/boost/CMakeLists.txt
@@ -5,8 +5,10 @@ set(FETCHCONTENT_QUIET OFF)
 include(FetchContent)
 
 
-set(hfc_REPOSITORY https://github.com/tipi-build/hfc)
 set(hfc_REVISION main)
+if(DEFINED ENV{COMMIT_ID} AND NOT "$ENV{COMMIT_ID}" STREQUAL "")
+    set(hfc_REVISION "$ENV{COMMIT_ID}")
+endif()
 
 include(HermeticFetchContent OPTIONAL RESULT_VARIABLE hfc_included) 
 if(NOT hfc_included)

--- a/example/get-started/CMakeLists.txt
+++ b/example/get-started/CMakeLists.txt
@@ -5,11 +5,16 @@ project(
   VERSION 1.0
   LANGUAGES CXX)
 
+set(hfc_REVISION main)
+if(DEFINED ENV{COMMIT_ID} AND NOT "$ENV{COMMIT_ID}" STREQUAL "")
+    set(hfc_REVISION "$ENV{COMMIT_ID}")
+endif()
 # Bootstrap hfc : Copy this after your project() call
+
 include(FetchContent)
 FetchContent_Populate(hfc
   GIT_REPOSITORY https://github.com/tipi-build/hfc.git
-  GIT_TAG main
+  GIT_TAG ${hfc_REVISION}
   SOURCE_DIR "${PROJECT_SOURCE_DIR}/thirdparty/cache/hfc/src"
   SUBBUILD_DIR "${PROJECT_SOURCE_DIR}/thirdparty/cache/hfc/subbuild"
   BINARY_DIR "${PROJECT_SOURCE_DIR}/thirdparty/cache/hfc/bin"

--- a/example/get-started/environments/linux-tipi-ubuntu-cxx17.cmake
+++ b/example/get-started/environments/linux-tipi-ubuntu-cxx17.cmake
@@ -1,0 +1,34 @@
+find_program(CMAKE_C_COMPILER clang)
+find_program(CMAKE_CXX_COMPILER clang++)
+
+if(NOT CMAKE_C_COMPILER)
+  message(FATAL_ERROR "clang not found")
+endif()
+
+if(NOT CMAKE_CXX_COMPILER)
+  message(FATAL_ERROR "clang++ not found")
+endif()
+
+set(
+    CMAKE_C_COMPILER
+     "${CMAKE_C_COMPILER}"
+    CACHE
+    STRING
+    "C compiler"
+    FORCE
+)
+
+set(
+    CMAKE_CXX_COMPILER
+     "${CMAKE_CXX_COMPILER}"
+    CACHE
+    STRING
+    "C++ compiler"
+    FORCE
+)
+
+set(CMAKE_CXX_FLAGS_INIT "-std=c++17" CACHE STRING "" FORCE)  
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ Standard (toolchain)" FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED YES CACHE BOOL "C++ Standard required" FORCE)
+set(CMAKE_CXX_EXTENSIONS NO CACHE BOOL "C++ Standard extensions" FORCE)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "fPIC" FORCE)

--- a/example/get-started/environments/linux-tipi-ubuntu-cxx17.pkr.js
+++ b/example/get-started/environments/linux-tipi-ubuntu-cxx17.pkr.js
@@ -1,0 +1,10 @@
+{
+  "variables": { },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
+      "commit": true
+    }
+  ]
+}

--- a/example/grpc_use_3rd_party_cmake_modules/environments/linux-tipi-ubuntu-cxx17.cmake
+++ b/example/grpc_use_3rd_party_cmake_modules/environments/linux-tipi-ubuntu-cxx17.cmake
@@ -1,0 +1,34 @@
+find_program(CMAKE_C_COMPILER clang)
+find_program(CMAKE_CXX_COMPILER clang++)
+
+if(NOT CMAKE_C_COMPILER)
+  message(FATAL_ERROR "clang not found")
+endif()
+
+if(NOT CMAKE_CXX_COMPILER)
+  message(FATAL_ERROR "clang++ not found")
+endif()
+
+set(
+    CMAKE_C_COMPILER
+     "${CMAKE_C_COMPILER}"
+    CACHE
+    STRING
+    "C compiler"
+    FORCE
+)
+
+set(
+    CMAKE_CXX_COMPILER
+     "${CMAKE_CXX_COMPILER}"
+    CACHE
+    STRING
+    "C++ compiler"
+    FORCE
+)
+
+set(CMAKE_CXX_FLAGS_INIT "-std=c++17" CACHE STRING "" FORCE)  
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ Standard (toolchain)" FORCE)
+set(CMAKE_CXX_STANDARD_REQUIRED YES CACHE BOOL "C++ Standard required" FORCE)
+set(CMAKE_CXX_EXTENSIONS NO CACHE BOOL "C++ Standard extensions" FORCE)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "fPIC" FORCE)

--- a/example/grpc_use_3rd_party_cmake_modules/environments/linux-tipi-ubuntu-cxx17.pkr.js
+++ b/example/grpc_use_3rd_party_cmake_modules/environments/linux-tipi-ubuntu-cxx17.pkr.js
@@ -1,0 +1,10 @@
+{
+  "variables": { },
+  "builders": [
+    {
+      "type": "docker",
+      "image": "tipibuild/tipi-ubuntu:{{cmake_re_source_hash}}",
+      "commit": true
+    }
+  ]
+}

--- a/example/grpc_use_3rd_party_cmake_modules/thirdparty/build_thirdparty.cmake
+++ b/example/grpc_use_3rd_party_cmake_modules/thirdparty/build_thirdparty.cmake
@@ -2,6 +2,9 @@ include(FetchContent)
 
 set(hfc_REPOSITORY https://github.com/tipi-build/hfc)
 set(hfc_REVISION main)
+if(DEFINED ENV{COMMIT_ID} AND NOT "$ENV{COMMIT_ID}" STREQUAL "")
+    set(hfc_REVISION "$ENV{COMMIT_ID}")
+endif()
 
 include(HermeticFetchContent OPTIONAL RESULT_VARIABLE hfc_included) 
 if(NOT hfc_included)

--- a/example/openssl/CMakeLists.txt
+++ b/example/openssl/CMakeLists.txt
@@ -3,8 +3,10 @@ project(hfc-openssl-example)
 
 include(FetchContent)
 
-set(hfc_REPOSITORY https://github.com/tipi-build/hfc)
 set(hfc_REVISION main)
+if(DEFINED ENV{COMMIT_ID} AND NOT "$ENV{COMMIT_ID}" STREQUAL "")
+    set(hfc_REVISION "$ENV{COMMIT_ID}")
+endif()
 
 include(HermeticFetchContent OPTIONAL RESULT_VARIABLE hfc_included) 
 if(NOT hfc_included)


### PR DESCRIPTION
Introduce a GitHub Actions workflow to automatically build all examples (boost, get-started, grpc, openssl) using both cmake-re and standard cmake.

Improve example reproducibility by allowing HFC revision to be overridden via the COMMIT_ID environment variable, enabling PR validation against the exact commit under test.

Add missing toolchain and environment files for examples, and align all example environments with cmake-re by using `cmake_re_source_hash`.

Change-Id: Ia95514901fa1570101129cf0e84c8f72368c29d9

Close https://github.com/tipi-build/specs-cmake-re/issues/465