### PR TITLE
TEST: Enable gRPC cmake-re example CI job

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -76,31 +76,31 @@ jobs:
           tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
           tipi run cmake --build ./build
 
-# This example is split into separate cmake-re and cmake jobs because it is significantly slower than others (gRPC dependency tree). Splitting improves CI parallelism and reduces overall execution time.
-#  build-example-with-grpc-cmake-re:
-#    name: build example grpc_use_3rd_party_cmake_modules with cmake-re
-#    runs-on: ubuntu-latest-8-cores
-#    container:
-#      image: tipibuild/tipi-ubuntu:latest
-#      options: --user root
-#    steps:
-#      - name: checkout pull request
-#        uses: actions/checkout@v4
-#        with:
-#          path: './hfc_project'
-#          ref: ${{ github.event.pull_request.head.sha }}
-#      - name: prepare example runner
-#        run: |
-#          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
-#          git init
-#          git config --global user.email "hello@tipi.build"
-#          git config --global user.name "tipibuild"
-#          tipi connect
-#      - name: build with cmake-re
-#        run: |
-#          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
-#          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
-#          cmake-re --build ./build_re --host
+ #This example is split into separate cmake-re and cmake jobs because it is significantly slower than others (gRPC dependency tree). Splitting improves CI parallelism and reduces overall execution time.
+  build-example-with-grpc-cmake-re:
+    name: build example grpc_use_3rd_party_cmake_modules with cmake-re
+    runs-on: ubuntu-latest-8-cores
+    container:
+      image: tipibuild/tipi-ubuntu:latest
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v4
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: prepare example runner
+        run: |
+          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
+          git init
+          git config --global user.email "hello@tipi.build"
+          git config --global user.name "tipibuild"
+          tipi connect
+      - name: build with cmake-re
+        run: |
+          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
+          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
+          cmake-re --build ./build_re --host
 
   build-example-with-grpc-cmake:
     name: build example grpc_use_3rd_party_cmake_modules with cmake


### PR DESCRIPTION
CHANGELOG
  - Enable CI testing of gRPC example with cmake-re

Change-Id: I5cd9adfff26457cfea4f2f142b7ccbaef8b3aeeb