### PR TITLE
Fix autotools configure skip after origin change in cmake-re mode

### DIFF
--- a/cmake/modules/hfc_autotools_restore_or_configure.cmake
+++ b/cmake/modules/hfc_autotools_restore_or_configure.cmake
@@ -66,33 +66,31 @@ function(hfc_autootols_configure
   # File to consider the configure step done
   already_configured_file
   )
-  if (NOT EXISTS "${already_configured_file}")
-    set(cmake_command ${OVERRIDEN_CMAKE_COMMAND} "-G" "${CMAKE_GENERATOR}" "--install-prefix" "${HERMETIC_PROJECT_INSTALL_PREFIX}" "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" "-S" "${cmake_adapter_parent_path}" "-B" "${AUTOTOOLS_IN_SOURCE_TREE_BUILD_DIR}" "-DCMAKE_TOOLCHAIN_FILE=${toolchain_file}")
+  set(cmake_command ${OVERRIDEN_CMAKE_COMMAND} "-G" "${CMAKE_GENERATOR}" "--install-prefix" "${HERMETIC_PROJECT_INSTALL_PREFIX}" "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" "-S" "${cmake_adapter_parent_path}" "-B" "${AUTOTOOLS_IN_SOURCE_TREE_BUILD_DIR}" "-DCMAKE_TOOLCHAIN_FILE=${toolchain_file}")
 
-    if (CMAKE_RE_ENABLE)
-      # --origin
-      list(APPEND cmake_command "--host") # TODO: we should somehow be able to detect if this is actually a "sub-build" already
-      list(APPEND cmake_command "--origin" "${origin}")
-    endif()
+  if (CMAKE_RE_ENABLE)
+    # --origin
+    list(APPEND cmake_command "--host") # TODO: we should somehow be able to detect if this is actually a "sub-build" already
+    list(APPEND cmake_command "--origin" "${origin}")
+  endif()
 
-    cmake_path(GET already_configured_file PARENT_PATH configured_marker_parent_path)
-    file(GLOB configure_markers "${configured_marker_parent_path}/hfc.*.configure.done")
-    if(configure_markers)
-      hfc_log_debug(" - clearing old configure markers")
-      file(REMOVE ${configure_markers})
-    endif()
+  cmake_path(GET already_configured_file PARENT_PATH configured_marker_parent_path)
+  file(GLOB configure_markers "${configured_marker_parent_path}/hfc.*.configure.done")
+  if(configure_markers)
+    hfc_log_debug(" - clearing old configure markers")
+    file(REMOVE ${configure_markers})
+  endif()
 
-    execute_process(
-      COMMAND ${cmake_command}
-      RESULT_VARIABLE CONFIGURE_RESULT
-      COMMAND_ECHO STDOUT
-    )
+  execute_process(
+    COMMAND ${cmake_command}
+    RESULT_VARIABLE CONFIGURE_RESULT
+    COMMAND_ECHO STDOUT
+  )
 
-    if(${CONFIGURE_RESULT} EQUAL 0)
-      file(TOUCH "${already_configured_file}")
-    else()
-      message(FATAL_ERROR "Failed to configure ${content_name}")
-    endif()
+  if(${CONFIGURE_RESULT} EQUAL 0)
+    file(TOUCH "${already_configured_file}")
+  else()
+    message(FATAL_ERROR "Failed to configure ${content_name}")
   endif()
 
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,7 @@ set(test_source_files
     "${CMAKE_CURRENT_LIST_DIR}/check_source_build_hfc_prefix.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_subdir.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_subproject_targets_linking.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/check_update_origin.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_version_update.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/check_without_install.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/configure_stability_test.cpp"
@@ -119,3 +120,4 @@ endforeach()
 set_tests_properties (goldilock_provisioning_test  PROPERTIES
     ENVIRONMENT "FAKE_GOLDILOCK=$<TARGET_FILE:goldilock>;TRUE_GOLDILOCK=${HERMETIC_FETCHCONTENT_goldilock_BIN};STANDARD_COMPILER=${CMAKE_CXX_COMPILER}")
 set_tests_properties(check_find_package PROPERTIES WILL_FAIL TRUE)
+set_tests_properties(check_update_origin PROPERTIES ENVIRONMENT "TIPI_CACHE_CONSUME_ONLY=ON")

--- a/test/check_update_origin.cpp
+++ b/test/check_update_origin.cpp
@@ -1,0 +1,112 @@
+#define BOOST_TEST_MODULE check_update_origin_with_workaround
+#include <boost/test/included/unit_test.hpp>
+
+#include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process.hpp>
+
+#include <test_project.hpp>
+#include <test_variant.hpp>
+#include <test_helpers.hpp>
+#include <test_isolation_fixture.hpp>
+
+#include <pre/file/string.hpp>
+
+
+namespace hfc::test {
+  namespace fs = boost::filesystem;
+  namespace bp = boost::process;
+  using namespace std::string_literals;
+
+  struct deps_config {
+    std::string repository_url{};
+    std::string git_tag{};
+  };
+
+  BOOST_DATA_TEST_CASE_F(test_isolation_fixture, check_update_origin_with_workaround, boost::unit_test::data::make(hfc::test::test_variants()), data){
+    deps_config original_cmake_config{
+      "https://github.com/tipi-build/unit-test-cmake-template-2libs.git",
+      "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92"
+    };
+
+    deps_config original_autotools_config{
+      "https://github.com/tipi-build/unittest-autotools-sample.git",
+      "ad80b024eeda8f4c0a96eedf669dc453ed33a094"
+    };
+
+    deps_config fork_cmake_config{
+      "https://github.com/nxxm/unit-test-cmake-template-2libs.git",
+      "5a17249c3f09cbad5be52b42a44d1453071c0d24"
+    };
+
+    deps_config fork_autotools_config{
+      "https://github.com/nxxm/unittest-autotools-sample.git",
+      "da659594da39c7a3061407ed100bed1b36dbb7bc"
+    };
+
+    fs::path test_project_path = prepare_project_to_be_tested("check_update_origin", data.is_cmake_re, temp_dir);
+    write_simple_main(test_project_path, {"MathFunctions.h", "MathFunctionscbrt.h", "lib.h"});
+    std::string cmake_configure_command = get_cmake_configure_command(test_project_path, data);
+
+    {
+      auto configure_output = run_command(cmake_configure_command, test_project_path, test_env);
+      BOOST_REQUIRE(boost::contains(configure_output, "thirdparty/cache"));
+      BOOST_REQUIRE(!boost::contains(configure_output, "thirdparty/v2_cache"));
+    }
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path, test_env);
+
+    fs::path real_source_path;
+    if (fs::is_symlink(test_project_path / "build")) {
+      fs::path build_folder_mirror = fs::read_symlink(test_project_path / "build").parent_path().parent_path();
+      real_source_path = build_folder_mirror.parent_path() / build_folder_mirror.stem();
+    } else {
+      real_source_path = test_project_path;
+    }
+
+    BOOST_REQUIRE(fs::exists(real_source_path / "thirdparty" / "cache" / "mathlib-subbuild"));
+    BOOST_REQUIRE(fs::exists(real_source_path / "thirdparty" / "cache" / "iconv-subbuild"));
+
+    {
+      auto content = pre::file::to_string((test_project_path / "CMakeLists.txt").generic_string());
+      boost::replace_all(content, original_cmake_config.repository_url, fork_cmake_config.repository_url);
+      boost::replace_all(content, original_cmake_config.git_tag, fork_cmake_config.git_tag);
+      boost::replace_all(content, original_autotools_config.repository_url, fork_autotools_config.repository_url);
+      boost::replace_all(content, original_autotools_config.git_tag, fork_autotools_config.git_tag);
+      boost::replace_all(content,
+        "  LANGUAGES CXX)\n",
+        "  LANGUAGES CXX)\n\nset(HERMETIC_FETCHCONTENT_SOURCE_CACHE_DIR \"${CMAKE_SOURCE_DIR}/thirdparty/v2_cache\")\n");
+      pre::file::from_string((test_project_path / "CMakeLists.txt").generic_string(), content);
+    }
+
+    {
+      auto configure_output = run_command(cmake_configure_command, test_project_path, test_env);
+      BOOST_REQUIRE(boost::contains(configure_output, "thirdparty/v2_cache"));
+      BOOST_REQUIRE(!boost::contains(configure_output, "thirdparty/cache"));
+
+    }
+
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path, test_env);
+    BOOST_REQUIRE(fs::exists(real_source_path / "thirdparty" / "v2_cache" / "mathlib-subbuild"));
+    BOOST_REQUIRE(fs::exists(real_source_path / "thirdparty" / "v2_cache" / "iconv-subbuild"));
+
+    {
+      auto content = pre::file::to_string((test_project_path / "CMakeLists.txt").generic_string());
+      boost::replace_all(content, fork_cmake_config.repository_url, original_cmake_config.repository_url);
+      boost::replace_all(content, fork_cmake_config.git_tag, original_cmake_config.git_tag);
+      boost::replace_all(content, fork_autotools_config.repository_url, original_autotools_config.repository_url);
+      boost::replace_all(content, fork_autotools_config.git_tag, original_autotools_config.git_tag);
+      boost::replace_all(content,
+        "\nset(HERMETIC_FETCHCONTENT_SOURCE_CACHE_DIR \"${CMAKE_SOURCE_DIR}/thirdparty/v2_cache\")\n",
+        "\n");
+      pre::file::from_string((test_project_path / "CMakeLists.txt").generic_string(), content);
+    }
+    {
+      test_env["HERMETIC_FETCHCONTENT_LOG_DEBUG"] = "ON";
+      auto configure_output = run_command(cmake_configure_command, test_project_path, test_env);
+      BOOST_REQUIRE(boost::contains(configure_output, "thirdparty/cache"));
+      BOOST_REQUIRE(!boost::contains(configure_output, "thirdparty/v2_cache"));
+    }
+    run_command(get_cmake_build_command(test_project_path, data), test_project_path, test_env);
+  }
+}

--- a/test/check_version_update.cpp
+++ b/test/check_version_update.cpp
@@ -22,6 +22,10 @@ namespace hfc::test {
   BOOST_DATA_TEST_CASE_F(test_isolation_fixture, check_version_update, boost::unit_test::data::make(hfc::test::test_variants()), data){
     std::string first_commit = "790f82e8a01b062b34133ef71dd94e9468717f37";
     std::string second_commit = "5cfd9d4e490d910acef72782e058739a83837305";
+
+    std::string first_commit_autotools = "ad80b024eeda8f4c0a96eedf669dc453ed33a094";
+    std::string second_commit_autotools = "30258ed5d3227cd37500af8cded3cdc241c288a2";
+
     fs::path test_project_path = prepare_project_to_be_tested("check_version_update", data.is_cmake_re, temp_dir);
     write_simple_main(test_project_path, {"version.hpp"});
     write_simple_main(test_project_path, {}, "simple_main.cpp" );
@@ -42,11 +46,20 @@ namespace hfc::test {
 
     auto content = pre::file::to_string((test_project_path/ "CMakeLists.txt").generic_string());
     boost::replace_all(content, first_commit, second_commit);
+    boost::replace_all(content, first_commit_autotools, second_commit_autotools);
     pre::file::from_string((test_project_path/ "CMakeLists.txt").generic_string(), content);
 
     result = run_cmd(test_env, bp::start_dir=(test_project_path), bp::shell, cmake_configure_command);
     BOOST_REQUIRE(result.return_code == 0);
     content_cmake_cache = pre::file::to_string(cmake_cache_path.generic_string());
     BOOST_REQUIRE(boost::contains(content_cmake_cache, "FAKECACHEDEP_MODE:STRING=v2"));
+
+    boost::replace_all(content, second_commit, first_commit);
+    boost::replace_all(content, second_commit_autotools, first_commit_autotools);
+    pre::file::from_string((test_project_path/ "CMakeLists.txt").generic_string(), content);
+    result = run_cmd(test_env, bp::start_dir=(test_project_path), bp::shell, cmake_configure_command);
+    BOOST_REQUIRE(result.return_code == 0);
+    content_cmake_cache = pre::file::to_string(cmake_cache_path.generic_string());
+    BOOST_REQUIRE(boost::contains(content_cmake_cache, "FAKECACHEDEP_MODE:STRING=v1"));
   }
 }

--- a/test/test_project_templates/check_update_origin/CMakeLists.txt
+++ b/test/test_project_templates/check_update_origin/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+set(FETCHCONTENT_QUIET OFF CACHE BOOL "" FORCE)
 cmake_minimum_required(VERSION 3.27.6)
 project(
   ModernCMakeExample
@@ -14,19 +14,18 @@ set(CMAKE_MODULE_PATH
 
 include(HermeticFetchContent)
 
-
 FetchContent_Declare(
-  "version_update"
-  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-version-update.git"
-  GIT_TAG "790f82e8a01b062b34133ef71dd94e9468717f37"
+  "mathlib"
+  GIT_REPOSITORY "https://github.com/tipi-build/unit-test-cmake-template-2libs.git"
+  GIT_TAG "ecc756a4c3f1811cdfd637bd6d8f4e3feb6aff92"
 )
 
 FetchContent_MakeHermetic(
-  "version_update"
+  "mathlib"
   HERMETIC_BUILD_SYSTEM cmake
 )
 
-HermeticFetchContent_MakeAvailableAtConfigureTime("version_update")
+HermeticFetchContent_MakeAvailableAtConfigureTime("mathlib")
 
 FetchContent_Declare(
   Iconv
@@ -47,7 +46,6 @@ FetchContent_MakeHermetic(
 
 HermeticFetchContent_MakeAvailableAtConfigureTime(Iconv)
 
-add_executable(MyExample simple_example.cpp)
-target_link_libraries(MyExample PRIVATE fakecachedep::fakecachedep Iconv::Iconv)
-add_executable(MySimpleMain simple_main.cpp)
 
+add_executable(MyExample simple_example.cpp)
+target_link_libraries(MyExample PRIVATE MathFunctions::MathFunctions MathFunctionscbrt::MathFunctionscbrt Iconv::Iconv)


### PR DESCRIPTION
## ***TL;DR***
- Fix a bug where autotools dependencies failed to reconfigure after switching dependency origins in cmake-re mode, causing `make: *** No targets specified and no makefile found`
- Add `check_update_origin` integration test validating the `HERMETIC_FETCHCONTENT_SOURCE_CACHE_DIR` workaround for origin switching

## Explanation
When using cmake-re with autotools dependencies (e.g. Iconv), changing the dependency origin (GIT_REPOSITORY/GIT_TAG) and then reverting back caused a build failure:
```
make: *** No targets specified and no makefile found. Stop.
```

**Root cause:** In cmake-re mode, `PROJECT_BINARY_DIR` is a symlink. When the origin changes, the mirror preparation (`hfc_autootols_prepare_mirror_build_tree_to_host_configure`) switches this symlink to a different mirror target.

The sequence is:
1. Outer logic checks the configure marker through the *current* symlink (pointing to step 2's mirror) -> not found -> `dep_need_configure = ON`
2. Mirror preparation switches the symlink back to step 1's mirror (same origin)
3. Sources are freshly cloned into `PROJECT_BINARY_DIR/src` (overwriting step 1's Makefile)
4. `hfc_autootols_configure` is called, but its inner guard `if (NOT EXISTS "${already_configured_file}")` now resolves through the *switched* symlink and finds step 1's stale marker -> **skips ./configure**
5. ExternalProject runs `make` in a directory with no Makefile -> failure

This is a TOCTOU (time-of-check-time-of-use) issue: the symlink target changes between when the decision to configure is made and when the configure function checks again.

**Why cmake deps are not affected:** cmake dependencies use `hfc_run_project_configure.cmake` which unconditionally deletes the binary dir before configuring. Autotools deps had an additional inner guard that was redundant with the caller's `dep_need_configure` check but became a bug due to the symlink switch.

Removed the redundant `if (NOT EXISTS "${already_configured_file}")` / `endif()` guard inside `hfc_autootols_configure`. The function now always executes when called. The caller (`hfc_autotools_restore_or_configure`) already properly gates invocation behind `dep_need_configure`.
