### PR TITLE
CONFIG : Add workflow_dispatch support for cmake-re docker image testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,30 @@
-name: build 
+name: build
+run-name: "${{ inputs.cmake_re_commit_sha && format('build - triggered by cmake-re ({0})', inputs.cmake_re_commit_sha) || github.event.pull_request.title || 'build' }}"
 
-# This workflow is triggered on PRs ony
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        description: 'Docker image to use (e.g. tipibuild/tipi-ubuntu:abc123)'
+        required: false
+        type: string
+      cmake_re_commit_sha:
+        description: 'cmake-re commit SHA'
+        required: false
+        type: string
+      callback_repo:
+        description: 'Repo (owner/repo) to post the resulting commit status to'
+        required: false
+        type: string
+      callback_sha:
+        description: 'Commit SHA to attach the resulting status to'
+        required: false
+        type: string
+      callback_context:
+        description: 'Commit status context, e.g. hfc/ci'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -14,11 +36,12 @@ env:
   TIPI_VAULT_PASSPHRASE: ${{ secrets.HFC_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}
 
 jobs:
-  build: 
+  build:
     name: Run HermeticFetchContent tests
     runs-on: ubuntu-latest-8-cores
-    container: 
-      image: tipibuild/tipi-ubuntu:latest
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
@@ -28,6 +51,9 @@ jobs:
           echo "TESTS_CACHED_HFC_TOOLS_DIR=$GITHUB_WORKSPACE/shared_hfc_tools_dir" >> $GITHUB_ENV
           echo "TESTS_CACHED_HFC_BASEDIR=$GITHUB_WORKSPACE/hfc_project_basedir" >> $GITHUB_ENV
           echo "HFC_TEST_DATA_DIR=$GITHUB_WORKSPACE/hfc_project/test/test_data" >> $GITHUB_ENV
+          if [ -n "${{ inputs.docker_image }}" ]; then
+            echo "HFC_TEST_SKIP_CMAKE=1" >> $GITHUB_ENV
+          fi
 
 
       - name: prepare runner
@@ -42,7 +68,7 @@ jobs:
       - name: Cached hfc tools dir
         if: ${{ env.build_with_cache == 'true' }} 
         id: win-cache-build-artifacts-restore
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             $TESTS_CACHED_HFC_TOOLS_DIR
@@ -57,10 +83,10 @@ jobs:
       #
       # This is necessary because we use the pull_request_target which requires a fully specified :ref: config
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:          
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 2 # we need at least two revisions in the cloned copy so that our upgrade testing work
 
       - name: tipi builds project 
@@ -116,6 +142,34 @@ jobs:
             --detach \
             --network=none \
             --workdir /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/hfc_project/build \
-            tipibuild/tipi-ubuntu:latest \
+            ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }} \
             sleep infinity
           docker exec --user root test-container-without-network tipi run ctest --verbose -j -R offline_source_override_test
+
+  # Reports this workflow's result back onto the cmake-re commit that dispatched
+  # it. Runs on always() so a failed/cancelled/timed-out build still resolves the
+  # 'pending' status the cmake-re side posted (otherwise its required check hangs).
+  # No-op for pull_request runs, where the callback inputs are absent.
+  report-status:
+    name: Report status to cmake-re
+    needs: [build]
+    if: ${{ always() && inputs.callback_repo != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post commit status
+        env:
+          GH_TOKEN: ${{ secrets.CMAKE_RE_STATUS_TOKEN }}
+          RESULT: ${{ needs.build.result }}
+        run: |
+          if [ "$RESULT" = "success" ]; then
+            STATE=success
+            DESC="HFC ci.yml passed"
+          else
+            STATE=failure
+            DESC="HFC ci.yml $RESULT"
+          fi
+          gh api -X POST "repos/${{ inputs.callback_repo }}/statuses/${{ inputs.callback_sha }}" \
+            -f state="$STATE" \
+            -f context="${{ inputs.callback_context }}" \
+            -f description="$DESC" \
+            -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,8 +1,30 @@
 name: example build
+run-name: "${{ inputs.cmake_re_commit_sha && format('example build - triggered by cmake-re ({0})', inputs.cmake_re_commit_sha) || github.event.pull_request.title || 'example build' }}"
 
-# This workflow is triggered on PRs ony
 on:
   pull_request:
+  workflow_dispatch:
+    inputs:
+      docker_image:
+        description: 'Docker image to use (e.g. tipibuild/tipi-ubuntu:abc123)'
+        required: false
+        type: string
+      cmake_re_commit_sha:
+        description: 'cmake-re commit SHA'
+        required: false
+        type: string
+      callback_repo:
+        description: 'Repo (owner/repo) to post the resulting commit status to'
+        required: false
+        type: string
+      callback_sha:
+        description: 'Commit SHA to attach the resulting status to'
+        required: false
+        type: string
+      callback_context:
+        description: 'Commit status context, e.g. hfc/example'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -12,22 +34,23 @@ env:
   TIPI_REFRESH_TOKEN: ${{ secrets.HFC_TIPI_TEST_USER_TIPI_REFRESH_TOKEN }}
   TIPI_VAULT_PASSPHRASE: ${{ secrets.HFC_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}
   TIPI_CACHE_CONSUME_ONLY: ON
-  COMMIT_ID: ${{ github.event.pull_request.head.sha }}
+  COMMIT_ID: ${{ github.event.pull_request.head.sha || github.sha }}
 
 
 jobs:
   build-example-boost:
     name: build example with boost
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
     container:
-      image: tipibuild/tipi-ubuntu:latest
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
     steps:
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: prepare example runner
         run: |
           cd hfc_project/example/boost
@@ -41,6 +64,7 @@ jobs:
           cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
           cmake-re --build ./build_re --host
       - name: build with cmake
+        if: ${{ !inputs.docker_image }}
         run: |
           cd hfc_project/example/boost
           tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
@@ -49,15 +73,16 @@ jobs:
   build-example-get-started:
     name: build example get-started
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
     container:
-      image: tipibuild/tipi-ubuntu:latest
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
     steps:
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: prepare example runner
         run: |
           cd hfc_project/example/get-started
@@ -71,6 +96,7 @@ jobs:
           cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
           cmake-re --build ./build_re --host
       - name: build with cmake
+        if: ${{ !inputs.docker_image }}
         run: |
           cd hfc_project/example/get-started
           tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
@@ -80,15 +106,16 @@ jobs:
   build-example-with-grpc-cmake-re:
     name: build example grpc_use_3rd_party_cmake_modules with cmake-re
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
     container:
-      image: tipibuild/tipi-ubuntu:latest
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
     steps:
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: prepare example runner
         run: |
           cd hfc_project/example/grpc_use_3rd_party_cmake_modules
@@ -102,18 +129,22 @@ jobs:
           cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
           cmake-re --build ./build_re --host
 
+  # Skipped when triggered externally (if: !inputs.docker_image), but image is still
+  # parametrized so that removing the 'if' guard doesn't silently run with the wrong image.
   build-example-with-grpc-cmake:
     name: build example grpc_use_3rd_party_cmake_modules with cmake
+    if: ${{ !inputs.docker_image }}
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
     container:
-      image: tipibuild/tipi-ubuntu:latest
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
     steps:
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: prepare example runner
         run: |
           cd hfc_project/example/grpc_use_3rd_party_cmake_modules
@@ -130,15 +161,16 @@ jobs:
   build-example-with-openssl:
     name: build example openssl
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
     container:
-      image: tipibuild/tipi-ubuntu:latest
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
     steps:
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: prepare example runner
         run: |
           cd hfc_project/example/openssl
@@ -152,6 +184,7 @@ jobs:
           cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
           cmake-re --build ./build_re --host
       - name: build with cmake
+        if: ${{ !inputs.docker_image }}
         run: |
           cd hfc_project/example/openssl
           tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
@@ -160,15 +193,16 @@ jobs:
   build-example-with-arrow-cmake-re:
     name: build example arrow with cmake-re
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
     container:
-      image: tipibuild/tipi-ubuntu:latest
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
     steps:
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: prepare example runner
         run: |
           cd hfc_project/example/arrow
@@ -182,18 +216,22 @@ jobs:
           cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
           cmake-re --build ./build_re --host
 
+  # Skipped when triggered externally (if: !inputs.docker_image), but image is still
+  # parametrized so that removing the 'if' guard doesn't silently run with the wrong image.
   build-example-with-arrow-cmake:
     name: build example arrow with cmake
+    if: ${{ !inputs.docker_image }}
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
     container:
-      image: tipibuild/tipi-ubuntu:latest
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
       options: --user root
     steps:
       - name: checkout pull request
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: './hfc_project'
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: prepare example runner
         run: |
           cd hfc_project/example/arrow
@@ -206,3 +244,40 @@ jobs:
           cd hfc_project/example/arrow
           tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
           tipi run cmake --build ./build
+
+  # Reports this workflow's result back onto the cmake-re commit that dispatched
+  # it. Runs on always() so a failed/cancelled/timed-out build still resolves the
+  # 'pending' status the cmake-re side posted (otherwise its required check hangs).
+  # Only depends on the cmake-re example jobs, since the cmake-only jobs are
+  # skipped on external dispatch. No-op for pull_request runs, where the callback
+  # inputs are absent.
+  report-status:
+    name: Report status to cmake-re
+    needs:
+      - build-example-boost
+      - build-example-get-started
+      - build-example-with-grpc-cmake-re
+      - build-example-with-openssl
+      - build-example-with-arrow-cmake-re
+    if: ${{ always() && inputs.callback_repo != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post commit status
+        env:
+          GH_TOKEN: ${{ secrets.CMAKE_RE_STATUS_TOKEN }}
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          STATE=success
+          DESC="HFC example.yml passed"
+          for r in $RESULTS; do
+            if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
+              STATE=failure
+              DESC="HFC example.yml failed (job result: $r)"
+              break
+            fi
+          done
+          gh api -X POST "repos/${{ inputs.callback_repo }}/statuses/${{ inputs.callback_sha }}" \
+            -f state="$STATE" \
+            -f context="${{ inputs.callback_context }}" \
+            -f description="$DESC" \
+            -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/test/test_variant.hpp
+++ b/test/test_variant.hpp
@@ -59,26 +59,32 @@ namespace hfc::test {
 
     std::vector<test_variant> tests_variants_to_run{};
 
-    auto cmake_path = bp::search_path("cmake");
-    if (cmake_path.string().empty()) {
-      auto error = std::runtime_error("ERROR: cmake is not found on PATH, tests can't be run.");
-      std::cout << error.what() << std::endl;
-      throw error;
-    }
-    tests_variants_to_run.push_back( test_variant{cmake_path, false} );
+    bool skip_cmake = std::getenv("HFC_TEST_SKIP_CMAKE") != nullptr;
+    bool skip_cmake_re = std::getenv("HFC_TEST_SKIP_CMAKE_RE") != nullptr;
 
-    auto cmake_re_path = bp::search_path("cmake-re");
-    if (cmake_re_path.string().empty()) {
-      auto error = std::runtime_error("ERROR: cmake-re is not found on PATH, tests can't be run.");
-      std::cout << error.what() << std::endl;
-      throw error;
-    }
-    tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv --host"} );  // host build
-
-    if(std::getenv("HFC_TEST_ENABLE_CONTAINERIZED_BUILDS_TEST") == "ON") {
-      tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv"} );       // /!\ no --host
+    if (skip_cmake && skip_cmake_re) {
+      throw std::runtime_error("Both HFC_TEST_SKIP_CMAKE and HFC_TEST_SKIP_CMAKE_RE are set, no test variants to run.");
     }
 
+    if(!skip_cmake) {
+      auto cmake_path = bp::search_path("cmake");
+      if (cmake_path.string().empty()) {
+        throw std::runtime_error("cmake is not found on PATH, tests can't be run.");
+      }
+      tests_variants_to_run.push_back( test_variant{cmake_path, false} );
+    }
+
+    if(!skip_cmake_re) {
+      auto cmake_re_path = bp::search_path("cmake-re");
+      if (cmake_re_path.string().empty()) {
+        throw std::runtime_error("cmake-re is not found on PATH, tests can't be run.");
+      }
+      tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv --host"} );  // host build
+
+      if(std::getenv("HFC_TEST_ENABLE_CONTAINERIZED_BUILDS_TEST") == "ON") {
+        tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv"} );       // /!\ no --host
+      }
+    }
 
     return tests_variants_to_run;
   }
@@ -87,47 +93,52 @@ namespace hfc::test {
 
     std::vector<test_variant> tests_variants_to_run{};
 
-    auto cmake_path = bp::search_path("cmake");
-    if (cmake_path.string().empty()) {
-      auto error = std::runtime_error("ERROR: cmake is not found on PATH, tests can't be run.");
-      std::cout << error.what() << std::endl;
-      throw error;
+    bool skip_cmake = std::getenv("HFC_TEST_SKIP_CMAKE") != nullptr;
+    bool skip_cmake_re = std::getenv("HFC_TEST_SKIP_CMAKE_RE") != nullptr;
+
+    if (skip_cmake && skip_cmake_re) {
+      throw std::runtime_error("Both HFC_TEST_SKIP_CMAKE and HFC_TEST_SKIP_CMAKE_RE are set, no test variants to run.");
     }
 
-    // Test with both GCC and Clang toolchains
-    // Structure: {toolchain_name, compiler_to_check}
     std::vector<std::pair<std::string, std::string>> toolchains = {
       {"linux-toolchain.cmake", "gcc"},
       {"linux-toolchain-clang.cmake", "clang"}
     };
 
-    for (const auto& [toolchain, compiler] : toolchains) {
-      auto compiler_path = bp::search_path(compiler);
-      if (compiler_path.string().empty()) {
-        std::cout << "WARNING: " << compiler << " is not found on PATH, skipping tests with " << toolchain << std::endl;
-        continue;
+    if(!skip_cmake) {
+      auto cmake_path = bp::search_path("cmake");
+      if (cmake_path.string().empty()) {
+        throw std::runtime_error("cmake is not found on PATH, tests can't be run.");
       }
 
-      tests_variants_to_run.push_back( test_variant{cmake_path, false, "", "", "", toolchain} );
+      for (const auto& [toolchain, compiler] : toolchains) {
+        auto compiler_path = bp::search_path(compiler);
+        if (compiler_path.string().empty()) {
+          std::cout << "WARNING: " << compiler << " is not found on PATH, skipping tests with " << toolchain << std::endl;
+          continue;
+        }
+
+        tests_variants_to_run.push_back( test_variant{cmake_path, false, "", "", "", toolchain} );
+      }
     }
 
-    auto cmake_re_path = bp::search_path("cmake-re");
-    if (cmake_re_path.string().empty()) {
-      auto error = std::runtime_error("ERROR: cmake-re is not found on PATH, tests can't be run.");
-      std::cout << error.what() << std::endl;
-      throw error;
-    }
-
-    for (const auto& [toolchain, compiler] : toolchains) {
-      auto compiler_path = bp::search_path(compiler);
-      if (compiler_path.string().empty()) {
-        continue;
+    if(!skip_cmake_re) {
+      auto cmake_re_path = bp::search_path("cmake-re");
+      if (cmake_re_path.string().empty()) {
+        throw std::runtime_error("cmake-re is not found on PATH, tests can't be run.");
       }
 
-      tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv --host", "", "", toolchain} );  // host build
+      for (const auto& [toolchain, compiler] : toolchains) {
+        auto compiler_path = bp::search_path(compiler);
+        if (compiler_path.string().empty()) {
+          continue;
+        }
 
-      if(std::getenv("HFC_TEST_ENABLE_CONTAINERIZED_BUILDS_TEST") == "ON") {
-        tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv", "", "", toolchain} );       // /!\ no --host
+        tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv --host", "", "", toolchain} );  // host build
+
+        if(std::getenv("HFC_TEST_ENABLE_CONTAINERIZED_BUILDS_TEST") == "ON") {
+          tests_variants_to_run.push_back( test_variant{cmake_re_path, true, "-vv", "", "", toolchain} );       // /!\ no --host
+        }
       }
     }
 


### PR DESCRIPTION
CHANGELOG
  - CI workflows can now be triggered manually with a custom docker image to validate cmake-re builds against HFC tests
  
Related pr https://github.com/nxxm/nxxm-src/pull/1705
Close https://github.com/tipi-build/specs-cmake-re/issues/502
