### PR TITLE
Add distributed (RBE) example CI builds

### DIFF
--- a/.github/actions/build-example/action.yml
+++ b/.github/actions/build-example/action.yml
@@ -1,0 +1,105 @@
+name: Build HFC example
+description: >
+  Builds one HFC example project in one of three modes: `cmake-re` (host),
+  plain `cmake`, or `cmake-re --distributed` (RBE). The distributed mode needs
+  the Docker CLI and the host Docker socket available inside the job container
+  (docker-in-docker), so it installs docker-ce-cli and writes the EngFlow auth
+  files. The caller is responsible for the container definition (including the
+  /var/run/docker.sock volume mount for distributed builds).
+
+inputs:
+  example:
+    description: Example directory under example/ (e.g. boost, arrow)
+    required: true
+  mode:
+    description: Build mode - one of "cmake-re", "cmake", "distributed"
+    required: true
+  toolchain:
+    description: Toolchain file, relative to the example directory
+    required: false
+    default: environments/linux-tipi-ubuntu-cxx17.cmake
+
+runs:
+  using: composite
+  steps:
+    - name: validate environment
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+      run: |
+        missing=()
+        for var in TIPI_ACCESS_TOKEN TIPI_REFRESH_TOKEN TIPI_VAULT_PASSPHRASE; do
+          [ -n "${!var}" ] || missing+=("$var")
+        done
+        if [ "$MODE" = "distributed" ]; then
+          for var in RBE_service EF_CERT EF_KEY; do
+            [ -n "${!var}" ] || missing+=("$var")
+          done
+        fi
+        if [ ${#missing[@]} -gt 0 ]; then
+          echo "::error::build-example: missing required workflow env var(s): ${missing[*]}" >&2
+          echo "Set them in the caller's top-level 'env:' block (they are not action inputs)." >&2
+          exit 1
+        fi
+        
+    - name: install docker (docker-in-docker)
+      if: ${{ inputs.mode == 'distributed' }}
+      shell: bash
+      run: |
+        apt update -y
+        apt install -y ca-certificates curl
+        install -m 0755 -d /etc/apt/keyrings
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        chmod a+r /etc/apt/keyrings/docker.asc
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+          tee /etc/apt/sources.list.d/docker.list > /dev/null
+        apt update -y
+        apt install -y docker-ce-cli
+
+    # EF_CERT / EF_KEY are provided as workflow-level env vars by the caller;
+    # composite actions cannot read the secrets context directly.
+    - name: write EngFlow cluster auth files
+      if: ${{ inputs.mode == 'distributed' }}
+      shell: bash
+      run: |
+        echo "${EF_CERT}" > /tmp/engflow.crt
+        echo "${EF_KEY}" > /tmp/engflow.key
+
+    - name: prepare example runner
+      shell: bash
+      run: |
+        cd hfc_project/example/${{ inputs.example }}
+        git init
+        git config --global user.email "hello@tipi.build"
+        git config --global user.name "tipibuild"
+        tipi connect
+
+    - name: build with cmake-re
+      if: ${{ inputs.mode == 'cmake-re' }}
+      shell: bash
+      run: |
+        cd hfc_project/example/${{ inputs.example }}
+        cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=${{ inputs.toolchain }} -DCMAKE_BUILD_TYPE=Release --host
+        cmake-re --build ./build_re --host
+
+    - name: build with cmake
+      if: ${{ inputs.mode == 'cmake' }}
+      shell: bash
+      run: |
+        cd hfc_project/example/${{ inputs.example }}
+        tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${{ inputs.toolchain }}
+        tipi run cmake --build ./build
+
+    - name: build with cmake-re --distributed
+      if: ${{ inputs.mode == 'distributed' }}
+      shell: bash
+      # RBE_service is provided as a workflow-level env var by the caller.
+      env:
+        RBE_tls_client_auth_cert: /tmp/engflow.crt
+        RBE_tls_client_auth_key: /tmp/engflow.key
+      run: |
+        cd hfc_project/example/${{ inputs.example }}
+        cmake-re -GNinja -S . -B build_distributed -DCMAKE_TOOLCHAIN_FILE=${{ inputs.toolchain }} -DCMAKE_BUILD_TYPE=Release --host --distributed
+        cmake-re --build ./build_distributed --host --distributed -j100

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -38,11 +38,16 @@ env:
   TIPI_VAULT_PASSPHRASE: ${{ secrets.HFC_TIPI_TEST_USER_TIPI_VAULT_PASSPHRASE }}
   TIPI_CACHE_CONSUME_ONLY: ON
   COMMIT_ID: ${{ github.event.pull_request.head.sha || github.sha }}
+  # Consumed by the build-example composite action for distributed (RBE) builds.
+  # Composite actions can't read the secrets context, so they're exposed here.
+  RBE_service: ${{ secrets.EF_CLUSTER_RBE_SERVICE }}
+  EF_CERT: ${{ secrets.EF_CLUSTER_CERT }}
+  EF_KEY: ${{ secrets.EF_CLUSTER_KEY }}
 
 
 jobs:
-  build-example-boost:
-    name: build example with boost
+  build-example-boost-cmake-re:
+    name: build example boost with cmake-re
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 90
     container:
@@ -54,27 +59,16 @@ jobs:
         with:
           path: './hfc_project'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: prepare example runner
-        run: |
-          cd hfc_project/example/boost
-          git init
-          git config --global user.email "hello@tipi.build"
-          git config --global user.name "tipibuild"
-          tipi connect
-      - name: build with cmake-re
-        run: |
-          cd hfc_project/example/boost
-          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
-          cmake-re --build ./build_re --host
-      - name: build with cmake
-        if: ${{ !inputs.docker_image }}
-        run: |
-          cd hfc_project/example/boost
-          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
-          tipi run cmake --build ./build
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: boost
+          mode: cmake-re
 
-  build-example-get-started:
-    name: build example get-started
+  # Skipped when triggered externally (if: !inputs.docker_image), but image is still
+  # parametrized so that removing the 'if' guard doesn't silently run with the wrong image.
+  build-example-boost-cmake:
+    name: build example boost with cmake
+    if: ${{ !inputs.docker_image }}
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 90
     container:
@@ -86,26 +80,48 @@ jobs:
         with:
           path: './hfc_project'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: prepare example runner
-        run: |
-          cd hfc_project/example/get-started
-          git init
-          git config --global user.email "hello@tipi.build"
-          git config --global user.name "tipibuild"
-          tipi connect
-      - name: build with cmake-re
-        run: |
-          cd hfc_project/example/get-started
-          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
-          cmake-re --build ./build_re --host
-      - name: build with cmake
-        if: ${{ !inputs.docker_image }}
-        run: |
-          cd hfc_project/example/get-started
-          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
-          tipi run cmake --build ./build
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: boost
+          mode: cmake
 
- #This example is split into separate cmake-re and cmake jobs because it is significantly slower than others (gRPC dependency tree). Splitting improves CI parallelism and reduces overall execution time.
+  build-example-get-started-cmake-re:
+    name: build example get-started with cmake-re
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: get-started
+          mode: cmake-re
+
+  build-example-get-started-cmake:
+    name: build example get-started with cmake
+    if: ${{ !inputs.docker_image }}
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: get-started
+          mode: cmake
+
   build-example-with-grpc-cmake-re:
     name: build example grpc_use_3rd_party_cmake_modules with cmake-re
     runs-on: ubuntu-latest-8-cores
@@ -119,21 +135,11 @@ jobs:
         with:
           path: './hfc_project'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: prepare example runner
-        run: |
-          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
-          git init
-          git config --global user.email "hello@tipi.build"
-          git config --global user.name "tipibuild"
-          tipi connect
-      - name: build with cmake-re
-        run: |
-          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
-          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
-          cmake-re --build ./build_re --host
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: grpc_use_3rd_party_cmake_modules
+          mode: cmake-re
 
-  # Skipped when triggered externally (if: !inputs.docker_image), but image is still
-  # parametrized so that removing the 'if' guard doesn't silently run with the wrong image.
   build-example-with-grpc-cmake:
     name: build example grpc_use_3rd_party_cmake_modules with cmake
     if: ${{ !inputs.docker_image }}
@@ -148,21 +154,13 @@ jobs:
         with:
           path: './hfc_project'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: prepare example runner
-        run: |
-          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
-          git init
-          git config --global user.email "hello@tipi.build"
-          git config --global user.name "tipibuild"
-          tipi connect
-      - name: build with cmake
-        run: |
-          cd hfc_project/example/grpc_use_3rd_party_cmake_modules
-          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
-          tipi run cmake --build ./build
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: grpc_use_3rd_party_cmake_modules
+          mode: cmake
 
-  build-example-with-openssl:
-    name: build example openssl
+  build-example-with-openssl-cmake-re:
+    name: build example openssl with cmake-re
     runs-on: ubuntu-latest-8-cores
     timeout-minutes: 90
     container:
@@ -174,24 +172,29 @@ jobs:
         with:
           path: './hfc_project'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: prepare example runner
-        run: |
-          cd hfc_project/example/openssl
-          git init
-          git config --global user.email "hello@tipi.build"
-          git config --global user.name "tipibuild"
-          tipi connect
-      - name: build with cmake-re
-        run: |
-          cd hfc_project/example/openssl
-          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
-          cmake-re --build ./build_re --host
-      - name: build with cmake
-        if: ${{ !inputs.docker_image }}
-        run: |
-          cd hfc_project/example/openssl
-          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
-          tipi run cmake --build ./build
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: openssl
+          mode: cmake-re
+
+  build-example-with-openssl-cmake:
+    name: build example openssl with cmake
+    if: ${{ !inputs.docker_image }}
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: openssl
+          mode: cmake
 
   build-example-with-arrow-cmake-re:
     name: build example arrow with cmake-re
@@ -206,21 +209,11 @@ jobs:
         with:
           path: './hfc_project'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: prepare example runner
-        run: |
-          cd hfc_project/example/arrow
-          git init
-          git config --global user.email "hello@tipi.build"
-          git config --global user.name "tipibuild"
-          tipi connect
-      - name: build with cmake-re
-        run: |
-          cd hfc_project/example/arrow
-          cmake-re -GNinja -S . -B build_re -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake -DCMAKE_BUILD_TYPE=Release --host
-          cmake-re --build ./build_re --host
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: arrow
+          mode: cmake-re
 
-  # Skipped when triggered externally (if: !inputs.docker_image), but image is still
-  # parametrized so that removing the 'if' guard doesn't silently run with the wrong image.
   build-example-with-arrow-cmake:
     name: build example arrow with cmake
     if: ${{ !inputs.docker_image }}
@@ -235,18 +228,110 @@ jobs:
         with:
           path: './hfc_project'
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: prepare example runner
-        run: |
-          cd hfc_project/example/arrow
-          git init
-          git config --global user.email "hello@tipi.build"
-          git config --global user.name "tipibuild"
-          tipi connect
-      - name: build with cmake
-        run: |
-          cd hfc_project/example/arrow
-          tipi run cmake -GNinja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=environments/linux-tipi-ubuntu-cxx17.cmake
-          tipi run cmake --build ./build
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: arrow
+          mode: cmake
+
+  build-example-boost-distributed:
+    name: build example boost with cmake-re --distributed
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: boost
+          mode: distributed
+
+  build-example-get-started-distributed:
+    name: build example get-started with cmake-re --distributed
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: get-started
+          mode: distributed
+
+  build-example-with-grpc-distributed:
+    name: build example grpc_use_3rd_party_cmake_modules with cmake-re --distributed
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: grpc_use_3rd_party_cmake_modules
+          mode: distributed
+
+  build-example-with-openssl-distributed:
+    name: build example openssl with cmake-re --distributed
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: openssl
+          mode: distributed
+
+  build-example-with-arrow-distributed:
+    name: build example arrow with cmake-re --distributed
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 90
+    container:
+      image: ${{ inputs.docker_image || 'tipibuild/tipi-ubuntu:latest' }}
+      options: --user root
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+    steps:
+      - name: checkout pull request
+        uses: actions/checkout@v5
+        with:
+          path: './hfc_project'
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: ./hfc_project/.github/actions/build-example
+        with:
+          example: arrow
+          mode: distributed
 
   # Reports this workflow's result back onto the cmake-re commit that dispatched
   # it. Runs on always() so a failed/cancelled/timed-out build still resolves the
@@ -257,11 +342,16 @@ jobs:
   report-status:
     name: Report status to cmake-re
     needs:
-      - build-example-boost
-      - build-example-get-started
+      - build-example-boost-cmake-re
+      - build-example-get-started-cmake-re
       - build-example-with-grpc-cmake-re
-      - build-example-with-openssl
+      - build-example-with-openssl-cmake-re
       - build-example-with-arrow-cmake-re
+      - build-example-boost-distributed
+      - build-example-get-started-distributed
+      - build-example-with-grpc-distributed
+      - build-example-with-openssl-distributed
+      - build-example-with-arrow-distributed
     if: ${{ always() && inputs.callback_repo != '' }}
     runs-on: ubuntu-latest
     steps:

--- a/example/arrow/thirdparty/build_thirdparty.cmake
+++ b/example/arrow/thirdparty/build_thirdparty.cmake
@@ -350,4 +350,4 @@ FetchContent_MakeHermetic(
    SBOM_SUPPLIER "The Apache Foundation"
 )
 
-HermeticFetchContent_MakeAvailableAtConfigureTime(arrow)
+HermeticFetchContent_MakeAvailableAtBuildTime(arrow)

--- a/example/grpc_use_3rd_party_cmake_modules/thirdparty/build_thirdparty.cmake
+++ b/example/grpc_use_3rd_party_cmake_modules/thirdparty/build_thirdparty.cmake
@@ -230,7 +230,7 @@ FetchContent_MakeHermetic(
   SBOM_SUPPLIER "Google Inc"
 )
 
-HermeticFetchContent_MakeAvailableAtConfigureTime(gRPC)
+HermeticFetchContent_MakeAvailableAtBuildTime(gRPC)
 
 include(hfc_provide_dependency_FINDPACKAGE)
 


### PR DESCRIPTION
- Add a `cmake-re --host --distributed` (EngFlow RBE) build variant for every
  example: boost, get-started, grpc, openssl, arrow. These run with
  docker-in-docker (mount `/var/run/docker.sock`, install `docker-ce-cli`).
- Introduce a `build-example` composite action that factors out the repeated
  per-example steps (docker setup, EngFlow auth, `tipi connect`, build) so the
  15 build jobs are thin wrappers selecting an `example` + `mode`.
  
 Close https://github.com/tipi-build/specs-cmake-re/issues/509

# Landing a change

HFC is a source package: we don't transform sources at release time, so every commit that lands on `main` must be releasable on its own. Please make sure this PR meets the following before it lands.

## Every commit stands on its own
- [x] The PR may contain multiple commits, but each one is self-contained and could be released as-is (their order matters).
- [x] Every commit builds and passes all checks on its own.
- [x] Every commit has a descriptive first line.
- [x] A `Change-Id:` line is present in each commit's trailer so it stays compatible with Gerrit.

## Linear history
- [x] The commits are rebased on top of the latest `main` (no merge commits).
- [x] All checks pass on the rebased commits.

## Landing
- [ ] Land the change using **Rebase and merge** to keep history linear.
